### PR TITLE
feat: keyboard news nav, client-fetched feeds, faster translations (v0.22.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,11 @@ A few optional knobs you can set by hand (the plugin manages the rest):
   from your own machine instead. Reddit is the headline case: it 403s
   datacenter IPs, but `www.reddit.com/r/<sub>/.rss` works from a normal
   machine. Items flow through rotation / nav / translation / summary exactly
-  like built-in sources — there's no per-source code, just URLs:
+  like built-in sources — there's no per-source code, just URLs.
+
+  Easiest way to add one: **`/claudenews:list add r/<sub>`** (or just ask
+  Claude — *"add r/rust"*); `/claudenews:list rmfeed r/<sub>` removes it. The
+  command writes this for you, and you can also edit it by hand:
 
   ```json
   "clientFeeds": [

--- a/README.md
+++ b/README.md
@@ -166,6 +166,17 @@ A few optional knobs you can set by hand (the plugin manages the rest):
   ]
   ```
 
+- **`navKeys`** — remap the keyboard-nav combo (default `ctrl+shift+←/→`). Set
+  the modifiers and the prev/next keys, then rerun `/claudenews:nav on` to apply:
+
+  ```json
+  "navKeys": { "modifiers": ["ctrl", "shift"], "prev": "left", "next": "right" }
+  ```
+
+  `modifiers` is any of `ctrl`/`shift`/`cmd`/`alt` (held together); `prev`/`next`
+  are any key names (`left`, `right`, `[`, `]`, …). Keep to a combo the shell
+  doesn't use (the `ctrl+shift` family) — picking one it does (e.g. `cmd`/`alt`
+  +arrow) means losing that shortcut inside the terminal.
 - **`summaryColor`** — SGR color for the summary lines (default `38;5;245`, a
   readable gray). e.g. `"37"` plain white, `"38;5;250"` lighter, `"38;5;240"`
   dimmer.

--- a/README.md
+++ b/README.md
@@ -73,8 +73,38 @@ the right command runs automatically.
 | `/claudenews:translate ko` | Force a target language (`ko`, `ja`, `zh`, `es`, …) |
 | `/claudenews:translate off` | Disable translation |
 | `/claudenews:list` | Show every source inline; toggle one or more by id (`/claudenews:list cnn bbc hn`) |
+| `/claudenews:nav on` | Browse news with `ctrl+shift+←/→` (macOS; installs a Hammerspoon key tap) |
+| `/claudenews:nav off` | Turn key navigation back off (per-session auto-rotation resumes) |
 | `/claudenews:feedback` | Send feedback / a bug report / a feature request to the maintainer |
 | `/claudenews:teardown` | Remove status line wiring (run before `/plugin remove`) |
+
+## Keyboard navigation (optional, macOS)
+
+By default the status line auto-rotates through news while the agent thinks.
+If you'd rather step through items yourself, turn on key navigation:
+
+```
+/claudenews:nav on
+```
+
+- **`ctrl+shift+→`** next · **`ctrl+shift+←`** previous
+- News becomes **global**: every Claude Code session shows the same item, so
+  stepping moves them all together.
+- Works in **iTerm2, Apple Terminal, WezTerm, kitty**. In any other app the
+  shortcut is left untouched (so it still selects text in your browser/editor).
+
+The key is captured by a tiny [Hammerspoon](https://www.hammerspoon.org) tap,
+so `nav on` needs Hammerspoon installed:
+
+```
+brew install --cask hammerspoon
+```
+
+The only manual step is a one-time macOS **Accessibility** grant for Hammerspoon
+— macOS pops the prompt the first time; click *Open System Settings* and toggle
+it on. `nav on` restarts Hammerspoon for you and sets the status-line refresh to
+1s so stepping feels instant. Disable it (and restore auto-rotation) anytime
+with `/claudenews:nav off`.
 
 ## Updating
 
@@ -114,6 +144,29 @@ The plugin picks sensible defaults on first run from your OS language.
 `/claudenews:list` prints the full menu; `/claudenews:list cnn bbc hn`
 toggles one or more by id. Public sources are fetched and cached by the
 backend; your selection just tells it what to merge.
+
+## Power-user config (`~/.claudenews/config.json`)
+
+A few optional knobs you can set by hand (the plugin manages the rest):
+
+- **`clientFeeds`** — add any RSS/Atom feed the backend can't reach, fetched
+  from your own machine instead. Reddit is the headline case: it 403s
+  datacenter IPs, but `www.reddit.com/r/<sub>/.rss` works from a normal
+  machine. Items flow through rotation / nav / translation / summary exactly
+  like built-in sources — there's no per-source code, just URLs:
+
+  ```json
+  "clientFeeds": [
+    {"name": "👽 r/ClaudeAI", "url": "https://www.reddit.com/r/ClaudeAI/.rss"},
+    {"name": "🐘 #rust", "url": "https://mastodon.social/tags/rust.rss", "lang": "en"}
+  ]
+  ```
+
+- **`summaryColor`** — SGR color for the summary lines (default `38;5;245`, a
+  readable gray). e.g. `"37"` plain white, `"38;5;250"` lighter, `"38;5;240"`
+  dimmer.
+- **`parentStatusLine`** — the status line claudenews chains underneath; set
+  automatically at setup from whatever you had before.
 
 ## Privacy
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claudenews",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "DevFeed — HackerNews and GitHub Trending in your status line while Claude Code thinks",
   "author": {
     "name": "bhpark1013",

--- a/plugin/commands/list.md
+++ b/plugin/commands/list.md
@@ -7,8 +7,11 @@ allowed-tools: Bash(bash:*)
 Show every news source with its on/off state, or toggle sources by id.
 
 - `/claudenews:list` — print the full inline menu (every source id +
-  flag + on/off). No window.
+  flag + on/off) plus your own client feeds. No window.
 - `/claudenews:list cnn bbc hn` — toggle one or more sources by id
+- `/claudenews:list add r/<sub>` — add your own feed: a subreddit, or any
+  RSS/Atom URL the backend can't reach (fetched on your machine)
+- `/claudenews:list rmfeed r/<sub>` — remove one of your own feeds
 
 The inline list **is** the menu — it shows exactly what you can pick
 and the exact ids to type. Run it with no args first to see options,
@@ -20,6 +23,10 @@ Raw slash-command arguments: `$ARGUMENTS`
 bash ${CLAUDE_PLUGIN_ROOT}/commands/list.sh $ARGUMENTS
 ```
 
-Report the script output verbatim. If the user asked conversationally
-(no explicit ids), show the list, then map their request to the ids and
-run the toggle for them.
+Report the script output verbatim. If the user asked conversationally, map
+their request to a `list.sh` call and run it:
+- "show / change / toggle sources" → show the list, then toggle by id.
+- "add r/rust" / "follow the rust subreddit" → `list.sh add r/rust`
+  (Reddit shorthand is `r/<sub>`).
+- "add this feed `<url>`" / any RSS/Atom link → `list.sh add <url>`.
+- "remove r/rust" / "drop that feed" → `list.sh rmfeed r/rust`.

--- a/plugin/commands/list.sh
+++ b/plugin/commands/list.sh
@@ -2,6 +2,8 @@
 # News-source management (explicit, no windows).
 #   list.sh                 -> inline list of every source with on/off state
 #   list.sh <id> [<id>...]  -> toggle one or more sources by id
+#   list.sh add r/<sub>     -> add your own feed (subreddit, or any RSS/Atom URL)
+#   list.sh rmfeed <match>  -> remove one of your own feeds
 #
 # The inline list is the menu: it shows every source id + flag + on/off,
 # so you see exactly what you can pick and how. Toggle by id explicitly.
@@ -138,11 +140,118 @@ if known:
 PY
 }
 
-# No args (or explicit text/list) -> show the full inline menu.
-if [ "$#" -eq 0 ] || [ "$1" = "text" ] || [ "$1" = "list" ]; then
-  print_text_list
-  exit 0
-fi
+# A client feed is any RSS/Atom URL fetched on THIS machine (for feeds the
+# backend can't reach, e.g. Reddit). Stored in config.json under clientFeeds.
+add_feed() {
+  python3 - "$CONFIG_FILE" "$@" <<'PY'
+import json, sys
+cfg_path = sys.argv[1]
+arg = (sys.argv[2] if len(sys.argv) > 2 else "").strip()
+name_override = " ".join(sys.argv[3:]).strip()
+try:
+    cfg = json.load(open(cfg_path))
+    if not isinstance(cfg, dict): cfg = {}
+except Exception:
+    cfg = {}
+low = arg.lower()
+url = name = None
+if low.startswith("r/") or low.startswith("/r/"):
+    sub = arg.split("r/", 1)[1].strip("/")
+    if sub:
+        url = "https://www.reddit.com/r/%s/.rss" % sub
+        name = name_override or ("\U0001F47D r/%s" % sub)
+elif low.startswith("http://") or low.startswith("https://"):
+    url = arg
+    name = name_override or arg.split("//", 1)[1].split("/")[0]
+if not url:
+    print("  Usage: /claudenews:list add r/<subreddit>   (or a full RSS/Atom URL)")
+    print("  e.g.   /claudenews:list add r/rust")
+    sys.exit(0)
+feeds = cfg.get("clientFeeds")
+if not isinstance(feeds, list): feeds = []
+if any(isinstance(f, dict) and f.get("url") == url for f in feeds):
+    print("  already added: %s" % url); sys.exit(0)
+feeds.append({"name": name, "url": url})
+cfg["clientFeeds"] = feeds
+with open(cfg_path, "w") as f:
+    json.dump(cfg, f, indent=2, ensure_ascii=False); f.write("\n")
+print("  added your feed: %s" % name)
+print("    %s" % url)
+PY
+}
 
-# One or more ids -> toggle each.
-toggle_ids "$@"
+remove_feed() {
+  python3 - "$CONFIG_FILE" "$@" <<'PY'
+import json, sys
+cfg_path = sys.argv[1]
+arg = (sys.argv[2] if len(sys.argv) > 2 else "").strip().lower()
+try:
+    cfg = json.load(open(cfg_path))
+except Exception:
+    cfg = {}
+feeds = (cfg or {}).get("clientFeeds")
+if not isinstance(feeds, list) or not feeds:
+    print("  you have no client feeds"); sys.exit(0)
+if arg.startswith("r/") or arg.startswith("/r/"):
+    arg = "reddit.com/r/%s/" % arg.split("r/", 1)[1].strip("/")
+if not arg:
+    print("  Usage: /claudenews:list rmfeed <r/sub | url-fragment | name>"); sys.exit(0)
+kept = [f for f in feeds if not (isinstance(f, dict) and
+        (arg in (f.get("url", "").lower()) or arg in (f.get("name", "").lower())))]
+n = len(feeds) - len(kept)
+if not n:
+    print("  no feed matched: %s" % arg); sys.exit(0)
+cfg["clientFeeds"] = kept
+with open(cfg_path, "w") as f:
+    json.dump(cfg, f, indent=2, ensure_ascii=False); f.write("\n")
+print("  removed %d feed(s) matching '%s'" % (n, arg))
+PY
+}
+
+print_client_feeds() {
+  python3 - "$CONFIG_FILE" <<'PY'
+import json, sys
+try:
+    cfg = json.load(open(sys.argv[1]))
+except Exception:
+    cfg = {}
+feeds = (cfg or {}).get("clientFeeds") or []
+if isinstance(feeds, list) and feeds:
+    print("  Your own feeds (fetched on this machine):")
+    for f in feeds:
+        if isinstance(f, dict):
+            print("     - %s  %s" % (f.get("name", ""), f.get("url", "")))
+print("  Add your own:  /claudenews:list add r/<subreddit>   (or any RSS URL)")
+PY
+}
+
+# Best-effort: warm a freshly added feed so it shows promptly (no-op offline).
+warm_feeds() {
+  [ -n "$CLAUDE_PLUGIN_ROOT" ] && [ -f "$CLAUDE_PLUGIN_ROOT/hooks/show-news.py" ] || return 0
+  local py=python3 c
+  for c in /opt/homebrew/bin/python3 /usr/local/bin/python3; do
+    [ -x "$c" ] && py="$c" && break
+  done
+  ( "$py" "$CLAUDE_PLUGIN_ROOT/hooks/show-news.py" --feeds-refresh >/dev/null 2>&1 & ) || true
+}
+
+# Dispatch.
+case "${1:-}" in
+  ""|text|list)
+    print_text_list
+    print_client_feeds
+    ;;
+  add)
+    shift
+    add_feed "$@"
+    warm_feeds
+    ;;
+  rmfeed|remove-feed)
+    shift
+    remove_feed "$@"
+    ;;
+  *)
+    # One or more ids -> toggle each.
+    toggle_ids "$@"
+    ;;
+esac

--- a/plugin/commands/nav.md
+++ b/plugin/commands/nav.md
@@ -1,0 +1,19 @@
+---
+description: Enable or disable claudenews key navigation — step the status-line news to the previous/next item with cmd+ctrl+←/→. Opt-in; installs a small Hammerspoon key tap only when turned on. Triggers when the user wants to browse/scroll news with arrow keys, e.g. "claudenews 키로 뉴스 넘기기 켜줘", "방향키로 뉴스 이동 활성화", "enable claudenews key nav", "turn off news arrow keys".
+argument-hint: "[on | off | status]"
+allowed-tools: Bash(bash:*)
+---
+
+Enable, disable, or check claudenews key navigation.
+
+- `/claudenews:nav on` — make news global + install the Hammerspoon key tap (cmd+ctrl+←/→)
+- `/claudenews:nav off` — disable and remove the wiring (per-session rotation resumes)
+- `/claudenews:nav status` — show current state
+
+Raw slash-command arguments: `$ARGUMENTS`
+
+```bash
+bash ${CLAUDE_PLUGIN_ROOT}/commands/nav.sh $ARGUMENTS
+```
+
+Report the script output verbatim. If Hammerspoon is not installed, walk the user through the printed install + Accessibility-permission steps.

--- a/plugin/commands/nav.md
+++ b/plugin/commands/nav.md
@@ -1,12 +1,12 @@
 ---
-description: Enable or disable claudenews key navigation — step the status-line news to the previous/next item with cmd+ctrl+←/→. Opt-in; installs a small Hammerspoon key tap only when turned on. Triggers when the user wants to browse/scroll news with arrow keys, e.g. "claudenews 키로 뉴스 넘기기 켜줘", "방향키로 뉴스 이동 활성화", "enable claudenews key nav", "turn off news arrow keys".
+description: Enable or disable claudenews key navigation — step the status-line news to the previous/next item with ctrl+shift+←/→. Opt-in; installs a small Hammerspoon key tap only when turned on. Triggers when the user wants to browse/scroll news with arrow keys, e.g. "claudenews 키로 뉴스 넘기기 켜줘", "방향키로 뉴스 이동 활성화", "enable claudenews key nav", "turn off news arrow keys".
 argument-hint: "[on | off | status]"
 allowed-tools: Bash(bash:*)
 ---
 
 Enable, disable, or check claudenews key navigation.
 
-- `/claudenews:nav on` — make news global + install the Hammerspoon key tap (cmd+ctrl+←/→)
+- `/claudenews:nav on` — make news global + install the Hammerspoon key tap (ctrl+shift+←/→)
 - `/claudenews:nav off` — disable and remove the wiring (per-session rotation resumes)
 - `/claudenews:nav status` — show current state
 

--- a/plugin/commands/nav.sh
+++ b/plugin/commands/nav.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+# Enable/disable claudenews key navigation (cmd+ctrl+←/→ to step news).
+# Usage: nav.sh [on|off|status]
+#
+# Only when ON does the feature install anything: a stable nav launcher and a
+# Hammerspoon snippet wired into ~/.hammerspoon/init.lua. OFF removes the wiring
+# and flips the flag back; per-session rotation resumes.
+
+set -e
+
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+CONFIG_DIR="$HOME/.claudenews"
+CONFIG_FILE="$CONFIG_DIR/config.json"
+HUD_DIR="$HOME/.claude/hud"
+NAV_LAUNCHER="$HUD_DIR/claudenews-nav"
+LUA_SRC="$PLUGIN_ROOT/hammerspoon/claudenews-nav.lua"
+LUA_DST="$CONFIG_DIR/claudenews-nav.lua"
+HS_INIT="$HOME/.hammerspoon/init.lua"
+
+mkdir -p "$CONFIG_DIR" "$HUD_DIR"
+[ -f "$CONFIG_FILE" ] || echo "{}" > "$CONFIG_FILE"
+
+ACTION="${1:-status}"
+
+set_flag() { # $1 = true|false
+  python3 - "$CONFIG_FILE" "$1" <<'PY'
+import json, sys
+path, val = sys.argv[1], sys.argv[2] == "true"
+try:
+    cfg = json.load(open(path))
+except Exception:
+    cfg = {}
+if not isinstance(cfg, dict):
+    cfg = {}
+cfg["navEnabled"] = val
+json.dump(cfg, open(path, "w"), indent=2, ensure_ascii=False)
+open(path, "a").write("\n")
+PY
+}
+
+# Idempotently add/remove the dofile block in ~/.hammerspoon/init.lua.
+manage_init() { # $1 = add|remove
+  python3 - "$HS_INIT" "$LUA_DST" "$1" <<'PY'
+import os, sys
+init_path, lua_dst, action = sys.argv[1], sys.argv[2], sys.argv[3]
+BEGIN = "-- >>> claudenews-nav >>>"
+END = "-- <<< claudenews-nav <<<"
+block = (
+    f"{BEGIN}\n"
+    f'dofile("{lua_dst}")\n'
+    f"{END}\n"
+)
+os.makedirs(os.path.dirname(init_path), exist_ok=True)
+text = ""
+if os.path.exists(init_path):
+    text = open(init_path).read()
+# strip any existing managed block first
+import re
+text = re.sub(re.escape(BEGIN) + r".*?" + re.escape(END) + r"\n?", "", text, flags=re.S)
+if action == "add":
+    if text and not text.endswith("\n"):
+        text += "\n"
+    text += block
+open(init_path, "w").write(text)
+PY
+}
+
+hammerspoon_installed() {
+  [ -d "/Applications/Hammerspoon.app" ] || command -v hs >/dev/null 2>&1
+}
+
+case "$ACTION" in
+  on)
+    set_flag true
+    cp "$LUA_SRC" "$LUA_DST"
+    cp "$PLUGIN_ROOT/hud/nav-launcher.sh" "$NAV_LAUNCHER"
+    chmod +x "$NAV_LAUNCHER"
+    manage_init add
+    echo "✅ claudenews key navigation ENABLED."
+    echo ""
+    echo "  • News is now GLOBAL: every Claude Code session shows the same item."
+    echo "  • Key: ctrl+←  (previous)   ctrl+→  (next)"
+    echo "  • Works in: iTerm2, Apple Terminal, WezTerm, kitty (others: key untouched)."
+    echo ""
+    if hammerspoon_installed; then
+      echo "  Hammerspoon detected. Reload its config to start the key tap:"
+      echo "      open -g hammerspoon://reload      (or click the menubar icon → Reload Config)"
+      echo "  First run will ask for Accessibility permission — grant it."
+    else
+      echo "  ⚠️  Hammerspoon is NOT installed — it captures the key. Install + grant permission:"
+      echo "      brew install --cask hammerspoon"
+      echo "      open -a Hammerspoon          # then System Settings → Privacy → Accessibility → enable Hammerspoon"
+      echo "      open -g hammerspoon://reload  # after enabling"
+    fi
+    echo ""
+    echo "  Wired into: $HS_INIT"
+    echo "  Disable anytime with:  /claudenews:nav off"
+    ;;
+  off)
+    set_flag false
+    manage_init remove
+    rm -f "$NAV_LAUNCHER" "$LUA_DST"
+    echo "✅ claudenews key navigation DISABLED. Per-session rotation resumes."
+    echo "  Reload Hammerspoon to drop the key tap:  open -g hammerspoon://reload"
+    ;;
+  status)
+    ENABLED=$(python3 -c "import json;print(json.load(open('$CONFIG_FILE')).get('navEnabled',False))" 2>/dev/null || echo "False")
+    echo "claudenews key navigation: $([ "$ENABLED" = "True" ] && echo ON || echo OFF)"
+    echo "  nav launcher : $([ -x "$NAV_LAUNCHER" ] && echo "installed ($NAV_LAUNCHER)" || echo "not installed")"
+    echo "  hammerspoon  : $(hammerspoon_installed && echo "installed" || echo "NOT installed")"
+    echo "  init.lua wire: $([ -f "$HS_INIT" ] && grep -q 'claudenews-nav' "$HS_INIT" && echo "present" || echo "absent")"
+    echo ""
+    echo "  Enable:  /claudenews:nav on    Disable:  /claudenews:nav off"
+    ;;
+  *)
+    echo "Usage: /claudenews:nav [on|off|status]"
+    ;;
+esac

--- a/plugin/commands/nav.sh
+++ b/plugin/commands/nav.sh
@@ -16,6 +16,7 @@ NAV_LAUNCHER="$HUD_DIR/claudenews-nav"
 LUA_SRC="$PLUGIN_ROOT/hammerspoon/claudenews-nav.lua"
 LUA_DST="$CONFIG_DIR/claudenews-nav.lua"
 HS_INIT="$HOME/.hammerspoon/init.lua"
+SETTINGS="$HOME/.claude/settings.json"
 
 mkdir -p "$CONFIG_DIR" "$HUD_DIR"
 [ -f "$CONFIG_FILE" ] || echo "{}" > "$CONFIG_FILE"
@@ -83,6 +84,29 @@ reload_hammerspoon() {
   n=0; while ! pgrep -x Hammerspoon >/dev/null 2>&1 && [ "$n" -lt 200 ]; do n=$((n + 1)); done
 }
 
+# Set the statusLine refresh cadence so key nav feels responsive. ONLY touches
+# the statusLine if our HUD owns it (setup was run) — never clobbers a statusLine
+# we don't control. Safe no-op if settings.json is missing/unparseable.
+set_refresh_interval() { # $1 = seconds
+  python3 - "$SETTINGS" "$1" <<'PY'
+import json, sys
+path, val = sys.argv[1], int(sys.argv[2])
+try:
+    s = json.load(open(path))
+except Exception:
+    sys.exit(0)
+sl = s.get("statusLine")
+if not isinstance(sl, dict) or "claudenews-hud" not in (sl.get("command") or ""):
+    sys.exit(0)  # not our statusLine — leave it alone
+if sl.get("refreshInterval") == val:
+    sys.exit(0)
+sl["refreshInterval"] = val
+json.dump(s, open(path, "w"), indent=2, ensure_ascii=False)
+open(path, "a").write("\n")
+print("  statusLine refreshInterval set to %ds (snappy key nav) — restart Claude Code to apply" % val)
+PY
+}
+
 case "$ACTION" in
   on)
     set_flag true
@@ -114,6 +138,7 @@ case "$ACTION" in
       echo "  rerun /claudenews:nav on (it launches Hammerspoon and loads the tap):"
       echo "      brew install --cask hammerspoon"
     fi
+    set_refresh_interval 1
     echo ""
     echo "  Wired into: $HS_INIT"
     echo "  Disable anytime with:  /claudenews:nav off"

--- a/plugin/commands/nav.sh
+++ b/plugin/commands/nav.sh
@@ -39,6 +39,35 @@ open(path, "a").write("\n")
 PY
 }
 
+# Human-readable key combo, honoring config.json -> navKeys (default ctrl+shift+←/→).
+# Mirrors the binding in claudenews-nav.lua and the hint in the HUD.
+nav_key_desc() {
+  python3 - "$CONFIG_FILE" <<'PY'
+import json, sys
+try:
+    cfg = json.load(open(sys.argv[1]))
+    if not isinstance(cfg, dict): cfg = {}
+except Exception:
+    cfg = {}
+nk = cfg.get("navKeys")
+alias = {"control": "ctrl", "command": "cmd", "option": "alt", "opt": "alt"}
+order = ["ctrl", "shift", "alt", "cmd"]
+sym = {"left": "←", "right": "→", "up": "↑", "down": "↓"}
+mods, prev, nxt = ["ctrl", "shift"], "left", "right"
+if isinstance(nk, dict):
+    have = set()
+    for m in (nk.get("modifiers") or []):
+        k = str(m).lower(); k = alias.get(k, k)
+        if k in order: have.add(k)
+    if have:
+        mods = [m for m in order if m in have]
+    if isinstance(nk.get("prev"), str): prev = nk["prev"].lower()
+    if isinstance(nk.get("next"), str): nxt = nk["next"].lower()
+m = "+".join(mods)
+print("%s+%s  (previous)   %s+%s  (next)" % (m, sym.get(prev, prev), m, sym.get(nxt, nxt)))
+PY
+}
+
 # Idempotently add/remove the dofile block in ~/.hammerspoon/init.lua.
 manage_init() { # $1 = add|remove
   python3 - "$HS_INIT" "$LUA_DST" "$1" <<'PY'
@@ -117,8 +146,10 @@ case "$ACTION" in
     echo "✅ claudenews key navigation ENABLED."
     echo ""
     echo "  • News is now GLOBAL: every Claude Code session shows the same item."
-    echo "  • Key: ctrl+shift+←  (previous)   ctrl+shift+→  (next)"
+    echo "  • Key: $(nav_key_desc)"
     echo "  • Works in: iTerm2, Apple Terminal, WezTerm, kitty (others: key untouched)."
+    echo "  • Change the keys: set \"navKeys\" in ~/.claudenews/config.json, then rerun nav on"
+    echo "      e.g.  \"navKeys\": { \"modifiers\": [\"ctrl\",\"shift\"], \"prev\": \"left\", \"next\": \"right\" }"
     echo ""
     if hammerspoon_installed; then
       # Load the tap for the user — no manual reload needed.
@@ -156,6 +187,7 @@ case "$ACTION" in
   status)
     ENABLED=$(python3 -c "import json;print(json.load(open('$CONFIG_FILE')).get('navEnabled',False))" 2>/dev/null || echo "False")
     echo "claudenews key navigation: $([ "$ENABLED" = "True" ] && echo ON || echo OFF)"
+    echo "  key combo    : $(nav_key_desc)"
     echo "  nav launcher : $([ -x "$NAV_LAUNCHER" ] && echo "installed ($NAV_LAUNCHER)" || echo "not installed")"
     echo "  hammerspoon  : $(hammerspoon_installed && echo "installed" || echo "NOT installed")"
     echo "  init.lua wire: $([ -f "$HS_INIT" ] && grep -q 'claudenews-nav' "$HS_INIT" && echo "present" || echo "absent")"

--- a/plugin/commands/nav.sh
+++ b/plugin/commands/nav.sh
@@ -69,6 +69,20 @@ hammerspoon_installed() {
   [ -d "/Applications/Hammerspoon.app" ] || command -v hs >/dev/null 2>&1
 }
 
+# Reliably (re)load init.lua so the key tap reflects the current wiring. We
+# RESTART the app rather than `open hammerspoon://reload` (a no-op unless the
+# user bound that URL handler) or AppleScript (off by default). A fresh launch
+# always re-reads init.lua, so the user never has to reload by hand. Bounded
+# spin-waits (no `sleep`) keep it portable.
+reload_hammerspoon() {
+  if pgrep -x Hammerspoon >/dev/null 2>&1; then
+    pkill -x Hammerspoon 2>/dev/null || true
+    n=0; while pgrep -x Hammerspoon >/dev/null 2>&1 && [ "$n" -lt 200 ]; do n=$((n + 1)); done
+  fi
+  open -g -a Hammerspoon 2>/dev/null || open -g /Applications/Hammerspoon.app 2>/dev/null || true
+  n=0; while ! pgrep -x Hammerspoon >/dev/null 2>&1 && [ "$n" -lt 200 ]; do n=$((n + 1)); done
+}
+
 case "$ACTION" in
   on)
     set_flag true
@@ -83,18 +97,22 @@ case "$ACTION" in
     echo "  • Works in: iTerm2, Apple Terminal, WezTerm, kitty (others: key untouched)."
     echo ""
     if hammerspoon_installed; then
-      # Auto-reload so the key tap starts immediately — no manual step.
-      open -g hammerspoon://reload >/dev/null 2>&1 || true
-      echo "  ✅ Hammerspoon reloaded — the key tap is starting."
+      # Load the tap for the user — no manual reload needed.
+      reload_hammerspoon
+      if pgrep -x Hammerspoon >/dev/null 2>&1; then
+        echo "  ✅ Hammerspoon (re)started — the key tap is now active."
+      else
+        echo "  ⚠️  Couldn't launch Hammerspoon automatically. Open it once:  open -a Hammerspoon"
+      fi
       echo ""
-      echo "  First time only: macOS will ask to allow Accessibility. Click"
-      echo "  \"Open System Settings\" and toggle Hammerspoon ON. If no prompt appears:"
+      echo "  The only manual step: if macOS pops an Accessibility prompt for"
+      echo "  Hammerspoon, click \"Open System Settings\" and toggle it ON."
+      echo "  No prompt and keys don't work? Enable it by hand, then rerun nav on:"
       echo "      open \"x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility\""
     else
-      echo "  ⚠️  Hammerspoon is NOT installed — it captures the key. Install + grant permission:"
+      echo "  ⚠️  Hammerspoon is NOT installed — it captures the key. Install it, then"
+      echo "  rerun /claudenews:nav on (it launches Hammerspoon and loads the tap):"
       echo "      brew install --cask hammerspoon"
-      echo "      open -a Hammerspoon          # then System Settings → Privacy → Accessibility → enable Hammerspoon"
-      echo "      open -g hammerspoon://reload  # after enabling"
     fi
     echo ""
     echo "  Wired into: $HS_INIT"
@@ -105,7 +123,10 @@ case "$ACTION" in
     manage_init remove
     rm -f "$NAV_LAUNCHER" "$LUA_DST"
     echo "✅ claudenews key navigation DISABLED. Per-session rotation resumes."
-    echo "  Reload Hammerspoon to drop the key tap:  open -g hammerspoon://reload"
+    if hammerspoon_installed; then
+      reload_hammerspoon
+      echo "  Hammerspoon reloaded — the key tap is removed."
+    fi
     ;;
   status)
     ENABLED=$(python3 -c "import json;print(json.load(open('$CONFIG_FILE')).get('navEnabled',False))" 2>/dev/null || echo "False")

--- a/plugin/commands/nav.sh
+++ b/plugin/commands/nav.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Enable/disable claudenews key navigation (cmd+ctrl+←/→ to step news).
+# Enable/disable claudenews key navigation (ctrl+shift+←/→ to step news).
 # Usage: nav.sh [on|off|status]
 #
 # Only when ON does the feature install anything: a stable nav launcher and a
@@ -79,13 +79,17 @@ case "$ACTION" in
     echo "✅ claudenews key navigation ENABLED."
     echo ""
     echo "  • News is now GLOBAL: every Claude Code session shows the same item."
-    echo "  • Key: ctrl+←  (previous)   ctrl+→  (next)"
+    echo "  • Key: ctrl+shift+←  (previous)   ctrl+shift+→  (next)"
     echo "  • Works in: iTerm2, Apple Terminal, WezTerm, kitty (others: key untouched)."
     echo ""
     if hammerspoon_installed; then
-      echo "  Hammerspoon detected. Reload its config to start the key tap:"
-      echo "      open -g hammerspoon://reload      (or click the menubar icon → Reload Config)"
-      echo "  First run will ask for Accessibility permission — grant it."
+      # Auto-reload so the key tap starts immediately — no manual step.
+      open -g hammerspoon://reload >/dev/null 2>&1 || true
+      echo "  ✅ Hammerspoon reloaded — the key tap is starting."
+      echo ""
+      echo "  First time only: macOS will ask to allow Accessibility. Click"
+      echo "  \"Open System Settings\" and toggle Hammerspoon ON. If no prompt appears:"
+      echo "      open \"x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility\""
     else
       echo "  ⚠️  Hammerspoon is NOT installed — it captures the key. Install + grant permission:"
       echo "      brew install --cask hammerspoon"

--- a/plugin/commands/setup.sh
+++ b/plugin/commands/setup.sh
@@ -63,7 +63,9 @@ else:
     settings["statusLine"] = {
         "type": "command",
         "command": f"node {hud}",
-        "refreshInterval": 2,
+        # 1s is the floor Claude Code honors (fractional values are unsupported);
+        # nav data updates in ~70ms, so this keeps the visible step latency ~<1s.
+        "refreshInterval": 1,
     }
     with open(settings_path, "w") as f:
         json.dump(settings, f, indent=2, ensure_ascii=False)

--- a/plugin/hammerspoon/claudenews-nav.lua
+++ b/plugin/hammerspoon/claudenews-nav.lua
@@ -1,0 +1,77 @@
+-- claudenews key navigation (managed by /claudenews:nav).
+--
+-- Captures ctrl+shift+←/→ and, ONLY when a supported terminal is frontmost,
+-- steps the (global) news prev/next instead of letting the key reach the app.
+-- Anywhere else the key passes through untouched.
+--
+-- Why ctrl+SHIFT+arrow (not ctrl+arrow): ctrl+arrow is bound to word-jump in
+-- shells (readline/zle), so capturing it would require an expensive ~90ms
+-- AppleScript probe per press to confirm Claude Code (vs a shell) is focused
+-- before swallowing. ctrl+shift+arrow is unused in terminal line-editing, so we
+-- can swallow it on a cheap frontmost-bundle-id check alone — no IPC, instant.
+-- Outside a terminal (browser/editor/IDE) ctrl+shift+arrow selects text, so we
+-- gate on "a supported terminal is frontmost" and pass it through everywhere else.
+--
+-- The activation command appends a `dofile(...)` of this file to
+-- ~/.hammerspoon/init.lua. Requires Hammerspoon + Accessibility permission.
+
+-- Stable nav launcher installed by `/claudenews:nav on`.
+local NAV = os.getenv("HOME") .. "/.claude/hud/claudenews-nav"
+local SHELL = os.getenv("SHELL") or "/bin/zsh"
+
+-- Keycodes: 123 = Left, 124 = Right.
+local LEFT, RIGHT = 123, 124
+
+-- Minimum gap between two nav steps. A held key (autorepeat) never steps more
+-- than once per press anyway (see below); this only rate-limits rapid distinct
+-- presses so mashing the key can't spawn a burst of launcher processes.
+local DEBOUNCE_S = 0.15
+
+-- Supported terminals: frontmost bundle id -> captured. Inside any of these,
+-- ctrl+shift+arrow is unused by the shell, so swallowing it breaks nothing.
+local TERMS = {
+  ["com.googlecode.iterm2"]  = true,
+  ["com.apple.Terminal"]     = true,
+  ["com.github.wez.wezterm"] = true,
+  ["net.kovidgoyal.kitty"]   = true,
+}
+
+local lastNavAt = 0
+
+-- Store the tap in a GLOBAL: a local in a dofile'd chunk gets garbage-collected
+-- right after load and the eventtap silently stops firing. A global reference
+-- keeps it alive for the session.
+if _G.__claudenewsNavTap then _G.__claudenewsNavTap:stop() end
+__claudenewsNavTap = hs.eventtap.new({ hs.eventtap.event.types.keyDown }, function(e)
+  local kc = e:getKeyCode()
+  if kc ~= LEFT and kc ~= RIGHT then return false end
+  local f = e:getFlags()
+  -- Require ctrl+shift together, and NOT cmd/alt; tolerate fn/numericpad (arrows
+  -- always carry the fn flag on macOS).
+  if not (f.ctrl and f.shift and not (f.cmd or f.alt)) then return false end
+
+  -- Gate: a supported terminal must be frontmost. This is an instant in-process
+  -- bundle-id lookup — no AppleScript/ps/tty probe. Outside a terminal the key
+  -- passes through so ctrl+shift+arrow still selects text in other apps.
+  local app = hs.application.frontmostApplication()
+  if not (app and TERMS[app:bundleID()]) then
+    return false
+  end
+
+  -- Capture it. Step the news once per physical press (autorepeat suppressed),
+  -- rate-limited so rapid presses can't spawn a flood of launcher processes.
+  local isRepeat = e:getProperty(hs.eventtap.event.properties.keyboardEventAutorepeat) == 1
+  if not isRepeat then
+    local now = hs.timer.secondsSinceEpoch()
+    if now - lastNavAt >= DEBOUNCE_S then
+      lastNavAt = now
+      -- Login shell so the launcher's python3 resolves on the user's PATH
+      -- (hs.task otherwise has a minimal PATH).
+      hs.task.new(SHELL, nil, { "-l", "-c", NAV .. " " .. (kc == RIGHT and "next" or "prev") }):start()
+    end
+  end
+  return true -- swallow: ctrl+shift+arrow never reaches the app
+end)
+__claudenewsNavTap:start()
+
+return __claudenewsNavTap

--- a/plugin/hammerspoon/claudenews-nav.lua
+++ b/plugin/hammerspoon/claudenews-nav.lua
@@ -1,16 +1,20 @@
 -- claudenews key navigation (managed by /claudenews:nav).
 --
--- Captures ctrl+shift+←/→ and, ONLY when a supported terminal is frontmost,
+-- Captures the nav key combo and, ONLY when a supported terminal is frontmost,
 -- steps the (global) news prev/next instead of letting the key reach the app.
 -- Anywhere else the key passes through untouched.
 --
--- Why ctrl+SHIFT+arrow (not ctrl+arrow): ctrl+arrow is bound to word-jump in
--- shells (readline/zle), so capturing it would require an expensive ~90ms
--- AppleScript probe per press to confirm Claude Code (vs a shell) is focused
--- before swallowing. ctrl+shift+arrow is unused in terminal line-editing, so we
--- can swallow it on a cheap frontmost-bundle-id check alone — no IPC, instant.
--- Outside a terminal (browser/editor/IDE) ctrl+shift+arrow selects text, so we
--- gate on "a supported terminal is frontmost" and pass it through everywhere else.
+-- Default combo is ctrl+SHIFT+arrow (not ctrl+arrow): ctrl+arrow is bound to
+-- word-jump in shells (readline/zle), so capturing it would require an expensive
+-- ~90ms AppleScript probe per press to confirm Claude Code (vs a shell) is
+-- focused before swallowing. ctrl+shift+arrow is unused in terminal line-editing,
+-- so we can swallow it on a cheap frontmost-bundle-id check alone — no IPC,
+-- instant. Outside a terminal (browser/editor/IDE) ctrl+shift+arrow selects text,
+-- so we gate on "a supported terminal is frontmost" and pass it through elsewhere.
+--
+-- The combo is overridable via ~/.claudenews/config.json (see loadNavKeys below).
+-- Picking a combo the shell DOES use (e.g. cmd/alt+arrow) means losing that
+-- shortcut inside the terminal — keep to a shell-unused combo (ctrl+shift+…).
 --
 -- The activation command appends a `dofile(...)` of this file to
 -- ~/.hammerspoon/init.lua. Requires Hammerspoon + Accessibility permission.
@@ -19,8 +23,44 @@
 local NAV = os.getenv("HOME") .. "/.claude/hud/claudenews-nav"
 local SHELL = os.getenv("SHELL") or "/bin/zsh"
 
--- Keycodes: 123 = Left, 124 = Right.
-local LEFT, RIGHT = 123, 124
+-- Key binding — overridable via ~/.claudenews/config.json:
+--   "navKeys": { "modifiers": ["ctrl", "shift"], "prev": "left", "next": "right" }
+-- modifiers: any of ctrl/shift/cmd/alt (held together; all others must be up).
+-- prev/next: any hs.keycodes.map name ("left","right","[","]","j", …).
+-- Read once at load; rerun /claudenews:nav on (restarts Hammerspoon) to apply.
+local function loadNavKeys()
+  local d = {
+    mods = { ctrl = true, shift = true, cmd = false, alt = false },
+    prev = "left",
+    next = "right",
+  }
+  local ok, cfg = pcall(hs.json.read, os.getenv("HOME") .. "/.claudenews/config.json")
+  if not ok or type(cfg) ~= "table" or type(cfg.navKeys) ~= "table" then return d end
+  local nk = cfg.navKeys
+  local mods = { ctrl = false, shift = false, cmd = false, alt = false }
+  local any = false
+  if type(nk.modifiers) == "table" then
+    for _, m in ipairs(nk.modifiers) do
+      m = tostring(m):lower()
+      if m == "ctrl" or m == "control" then mods.ctrl = true; any = true
+      elseif m == "shift" then mods.shift = true; any = true
+      elseif m == "cmd" or m == "command" then mods.cmd = true; any = true
+      elseif m == "alt" or m == "option" or m == "opt" then mods.alt = true; any = true end
+    end
+  end
+  -- Empty / unrecognized modifiers would swallow BARE arrows — never do that;
+  -- fall back to the safe default combo instead.
+  if not any then mods = d.mods end
+  local prev = (type(nk.prev) == "string" and nk.prev:lower()) or d.prev
+  local nxt = (type(nk.next) == "string" and nk.next:lower()) or d.next
+  return { mods = mods, prev = prev, next = nxt }
+end
+
+local NK = loadNavKeys()
+local MODS = NK.mods
+-- Keycodes: default 123 = Left, 124 = Right; resolved by name so any key works.
+local PREV_KC = hs.keycodes.map[NK.prev] or 123
+local NEXT_KC = hs.keycodes.map[NK.next] or 124
 
 -- Minimum gap between two nav steps. A held key (autorepeat) never steps more
 -- than once per press anyway (see below); this only rate-limits rapid distinct
@@ -28,7 +68,7 @@ local LEFT, RIGHT = 123, 124
 local DEBOUNCE_S = 0.15
 
 -- Supported terminals: frontmost bundle id -> captured. Inside any of these,
--- ctrl+shift+arrow is unused by the shell, so swallowing it breaks nothing.
+-- the (shell-unused) nav combo is free to swallow, so it breaks nothing.
 local TERMS = {
   ["com.googlecode.iterm2"]  = true,
   ["com.apple.Terminal"]     = true,
@@ -44,15 +84,19 @@ local lastNavAt = 0
 if _G.__claudenewsNavTap then _G.__claudenewsNavTap:stop() end
 __claudenewsNavTap = hs.eventtap.new({ hs.eventtap.event.types.keyDown }, function(e)
   local kc = e:getKeyCode()
-  if kc ~= LEFT and kc ~= RIGHT then return false end
+  if kc ~= PREV_KC and kc ~= NEXT_KC then return false end
   local f = e:getFlags()
-  -- Require ctrl+shift together, and NOT cmd/alt; tolerate fn/numericpad (arrows
-  -- always carry the fn flag on macOS).
-  if not (f.ctrl and f.shift and not (f.cmd or f.alt)) then return false end
+  -- Exact modifier match: every required modifier held, every other one up.
+  -- (fn/numericpad ignored — arrows always carry the fn flag on macOS.) Matching
+  -- only the configured set keeps the cheap frontmost-only gate valid.
+  if (not not f.ctrl)  ~= MODS.ctrl  then return false end
+  if (not not f.shift) ~= MODS.shift then return false end
+  if (not not f.cmd)   ~= MODS.cmd   then return false end
+  if (not not f.alt)   ~= MODS.alt   then return false end
 
   -- Gate: a supported terminal must be frontmost. This is an instant in-process
   -- bundle-id lookup — no AppleScript/ps/tty probe. Outside a terminal the key
-  -- passes through so ctrl+shift+arrow still selects text in other apps.
+  -- passes through so the combo still does its normal thing in other apps.
   local app = hs.application.frontmostApplication()
   if not (app and TERMS[app:bundleID()]) then
     return false
@@ -67,10 +111,10 @@ __claudenewsNavTap = hs.eventtap.new({ hs.eventtap.event.types.keyDown }, functi
       lastNavAt = now
       -- Login shell so the launcher's python3 resolves on the user's PATH
       -- (hs.task otherwise has a minimal PATH).
-      hs.task.new(SHELL, nil, { "-l", "-c", NAV .. " " .. (kc == RIGHT and "next" or "prev") }):start()
+      hs.task.new(SHELL, nil, { "-l", "-c", NAV .. " " .. (kc == NEXT_KC and "next" or "prev") }):start()
     end
   end
-  return true -- swallow: ctrl+shift+arrow never reaches the app
+  return true -- swallow: the nav combo never reaches the app
 end)
 __claudenewsNavTap:start()
 

--- a/plugin/hooks/background_claude.py
+++ b/plugin/hooks/background_claude.py
@@ -97,6 +97,23 @@ def build_background_env() -> dict[str, str]:
     return env
 
 
+_EMPTY_MCP_FILE = os.path.join(CONFIG_DIR, ".empty-mcp.json")
+
+
+def _empty_mcp_config_file() -> str:
+    """Path to a tiny MCP config declaring zero servers. Used with
+    --strict-mcp-config so background `claude --print` calls skip loading the
+    user's MCP servers entirely. Written once; recreated if missing."""
+    try:
+        if not os.path.exists(_EMPTY_MCP_FILE):
+            os.makedirs(CONFIG_DIR, exist_ok=True)
+            with open(_EMPTY_MCP_FILE, "w", encoding="utf-8") as f:
+                f.write('{"mcpServers":{}}')
+    except OSError:
+        pass
+    return _EMPTY_MCP_FILE
+
+
 def build_claude_command(
     prompt: str,
     *,
@@ -105,6 +122,13 @@ def build_claude_command(
     settings_path: str = CLAUDE_SETTINGS_FILE,
 ) -> list[str]:
     model = resolve_background_model(task_name, config=config)
+    # Disable MCP servers for background calls. The user's MCP servers (remote
+    # mcp-remote endpoints, npx-spawned figma/redis/etc.) add 2–12s of cold
+    # start to EVERY `claude --print`, dwarfing the (fast) Haiku translation
+    # itself. --strict-mcp-config + an empty --mcp-config loads none of them,
+    # cutting a translation from ~5–15s to ~3s. The prompt goes on stdin (see
+    # run_background_prompt), never as a positional arg, so the variadic
+    # --mcp-config can't swallow it.
     command = [
         "claude",
         "--print",
@@ -114,6 +138,9 @@ def build_claude_command(
         "",
         "--disable-slash-commands",
         "--no-session-persistence",
+        "--strict-mcp-config",
+        "--mcp-config",
+        _empty_mcp_config_file(),
     ]
 
     overrides = build_plugin_disable_overrides(settings_path=settings_path)
@@ -122,7 +149,6 @@ def build_claude_command(
             ["--settings", json.dumps(overrides, ensure_ascii=False, separators=(",", ":"))]
         )
 
-    command.append(prompt)
     return command
 
 
@@ -136,6 +162,7 @@ def run_background_prompt(
     os.makedirs(CONFIG_DIR, exist_ok=True)
     return subprocess.run(
         build_claude_command(prompt, task_name=task_name, config=config),
+        input=prompt,  # prompt on stdin, not argv (see build_claude_command)
         capture_output=True,
         text=True,
         encoding="utf-8",

--- a/plugin/hooks/show-news.py
+++ b/plugin/hooks/show-news.py
@@ -29,7 +29,7 @@ SOURCES_CACHE = os.path.join(CONFIG_DIR, ".sources-cache.json")
 GUIDES_CACHE = os.path.join(CONFIG_DIR, ".guides-cache.json")
 RECENT_FILE = os.path.join(CONFIG_DIR, ".recent")
 # Opt-in key-driven navigation (config.navEnabled). An ordered candidate list
-# + a global cursor let cmd+ctrl+←/→ step prev/next; a short pin keeps a manual
+# + a global cursor let ctrl+shift+←/→ step prev/next; a short pin keeps a manual
 # pick from being clobbered by auto-rotation.
 NEWS_LIST_FILE = os.path.join(CONFIG_DIR, ".news-list.json")
 NAV_STATE_FILE = os.path.join(CONFIG_DIR, ".nav-state.json")
@@ -830,7 +830,7 @@ def main():
         api_url = config.get("apiUrl", DEFAULT_API)
 
     # Opt-in key navigation makes news GLOBAL: every session reads the shared
-    # .current-news so cmd+ctrl+←/→ moves all panes together. When off, the
+    # .current-news so ctrl+shift+←/→ moves all panes together. When off, the
     # per-session rotation below is left exactly as it was.
     global_mode = nav_enabled(config)
     if global_mode:
@@ -1003,7 +1003,7 @@ def main():
             pass
 
     # Keep the nav cursor pointed at whatever auto-rotation just chose, so the
-    # next cmd+ctrl+→ steps forward from here. Unpinned (pinnedUntil=0).
+    # next ctrl+shift+→ steps forward from here. Unpinned (pinnedUntil=0).
     if global_mode and saved_list is not None:
         try:
             idx = next(i for i, it in enumerate(saved_list) if it.get("url") == url)

--- a/plugin/hooks/show-news.py
+++ b/plugin/hooks/show-news.py
@@ -28,6 +28,12 @@ SUMMARY_CACHE = os.path.join(CONFIG_DIR, ".summary-cache.json")
 SOURCES_CACHE = os.path.join(CONFIG_DIR, ".sources-cache.json")
 GUIDES_CACHE = os.path.join(CONFIG_DIR, ".guides-cache.json")
 RECENT_FILE = os.path.join(CONFIG_DIR, ".recent")
+# Opt-in key-driven navigation (config.navEnabled). An ordered candidate list
+# + a global cursor let cmd+ctrl+←/→ step prev/next; a short pin keeps a manual
+# pick from being clobbered by auto-rotation.
+NEWS_LIST_FILE = os.path.join(CONFIG_DIR, ".news-list.json")
+NAV_STATE_FILE = os.path.join(CONFIG_DIR, ".nav-state.json")
+NAV_PIN_SEC = 300
 SOURCES_TTL_SEC = 3600
 GUIDES_TTL_SEC = 3600
 # Global ring buffer (shared across ALL sessions): don't re-show a URL until
@@ -390,7 +396,10 @@ def cached_translation(title, target_lang):
 
 
 def launch_translator(title, target_lang):
-    """Spawn translator as background process. Non-blocking."""
+    """Spawn translator as background process. Non-blocking. Duplicate spawns for
+    a title already in flight are cheap and self-limiting: translator.py acquires
+    a self-releasing per-title lock and exits BEFORE the model call if another is
+    already running, then frees the lock on completion so retries aren't blocked."""
     try:
         subprocess.Popen(
             ["python3", TRANSLATOR, target_lang, title],
@@ -451,10 +460,18 @@ def cached_summary(url, target_lang):
     return summary
 
 
-def launch_summarizer(url, title, target_lang):
+def launch_summarizer(url, title, target_lang, raw_text=""):
+    # Duplicate spawns are cheap and self-limiting: summarizer.py holds a
+    # self-releasing per-url lock and exits early if one is already in flight.
+    # raw_text (optional) is feed-provided body for sources whose pages can't be
+    # scraped (Reddit/Mastodon/…) — summarizer.py uses it when the URL yields no
+    # description. Passed as argv (list form → no shell, safe for any content).
+    args = ["python3", SUMMARIZER, target_lang, url, title]
+    if raw_text:
+        args.append(raw_text)
     try:
         subprocess.Popen(
-            ["python3", SUMMARIZER, target_lang, url, title],
+            args,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             stdin=subprocess.DEVNULL,
@@ -463,6 +480,325 @@ def launch_summarizer(url, title, target_lang):
         )
     except Exception as e:
         log(f"summarizer launch failed: {e}")
+
+
+def prewarm_translations(items, target_lang, budget=5):
+    """Translate up to `budget` not-yet-cached titles from the list in the
+    background. Without this only the picked/landed item is translated, so
+    navigating shows many untranslated titles. Titles are cheap and cached
+    permanently, so this fills the whole list over a few invocations. Deduped by
+    cached_translation + translator.py's self-releasing per-title lock, so once
+    the list is translated later calls spawn nothing."""
+    warmed = 0
+    for it in items:
+        if warmed >= budget:
+            break
+        if not isinstance(it, dict):
+            continue
+        t = it.get("title") or ""
+        if not t or it.get("lang") == target_lang:
+            continue
+        if cached_translation(t, target_lang):
+            continue
+        launch_translator(t, target_lang)
+        warmed += 1
+    if warmed:
+        log(f"pre-warmed {warmed} translators ({target_lang})")
+    return warmed
+
+
+def nav_enabled(config):
+    return bool((config or {}).get("navEnabled"))
+
+
+# ── client-fetched feed sources ──────────────────────────────────────────────
+# News reaches one shared pool through two interchangeable TRANSPORTS:
+#   • server   — selected catalog ids sent to the API, fetched server-side
+#   • client   — RSS/Atom URLs fetched directly from THIS machine
+# Both yield the same item shape and flow through rotation / nav / translation /
+# summary identically — nothing downstream knows or cares which transport a item
+# came from. Client feeds exist for any feed the server can't reach: e.g. Reddit
+# 403s its .json and the server's datacenter IP, but www.reddit.com/r/<sub>/.rss
+# works from a normal machine with a browser UA. There is NO source-specific
+# code — Reddit/Mastodon/Bluesky/etc. are just URLs in the clientFeeds list:
+#   config: "clientFeeds": [
+#     {"name": "👽 r/programming", "url": "https://www.reddit.com/r/programming/.rss"},
+#     {"name": "🐘 #rust", "url": "https://mastodon.social/tags/rust.rss", "lang": "en"}
+#   ]
+CLIENTFEEDS_CACHE_FILE = os.path.join(CONFIG_DIR, ".clientfeeds-cache.json")
+CLIENTFEEDS_TTL_SEC = 900       # refetch a client feed at most every 15 min
+CLIENTFEED_PER_SOURCE = 12      # cap items kept per feed
+# A browser UA: required by Reddit, harmless for any other feed.
+CLIENTFEED_UA = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"
+)
+
+
+def parse_feed(xml_text):
+    """Parse RSS 2.0 or Atom into [{'title','link'}]. Namespace-agnostic: matches
+    on the local tag name so one parser handles every feed flavor."""
+    import xml.etree.ElementTree as ET
+    try:
+        root = ET.fromstring(xml_text)
+    except Exception:
+        return []
+
+    def lname(tag):
+        return tag.rsplit("}", 1)[-1].lower()
+
+    out = []
+    for el in root.iter():
+        if lname(el.tag) not in ("item", "entry"):
+            continue
+        title, link, bodies = None, None, {}
+        for child in el:
+            lt = lname(child.tag)
+            if lt == "title" and child.text and not title:
+                title = child.text.strip()
+            elif lt == "link":
+                href = child.get("href")            # Atom: <link href="..."/>
+                if href:
+                    if link is None or child.get("rel") in (None, "alternate"):
+                        link = href
+                elif child.text and not link:        # RSS: <link>text</link>
+                    link = child.text.strip()
+            elif lt in ("content", "encoded", "description", "summary") and child.text:
+                # Feed-provided body. Reddit/Mastodon/etc. carry the post text
+                # here, which is the only summarizable source for feeds whose
+                # pages block scraping. Prefer full content over a short summary.
+                bodies.setdefault(lt, child.text)
+        if title and link:
+            body = (
+                bodies.get("content") or bodies.get("encoded")
+                or bodies.get("description") or bodies.get("summary") or ""
+            )
+            out.append({"title": title, "link": link, "body": body})
+    return out
+
+
+def _strip_html(s):
+    import html as _html
+    if not s:
+        return ""
+    t = re.sub(r"<[^>]+>", " ", _html.unescape(s))
+    return re.sub(r"\s+", " ", t).strip()
+
+
+def fetch_client_feeds(feeds):
+    """Fetch each client feed URL directly and map entries to news items.
+    Source-agnostic; best-effort (a failing feed is logged and skipped)."""
+    out, seen = [], set()
+    for f in feeds:
+        if not isinstance(f, dict):
+            continue
+        url = (f.get("url") or "").strip()
+        if not url:
+            continue
+        name = (f.get("name") or "").strip() or url
+        lang = (f.get("lang") or "en").strip() or "en"
+        try:
+            req = urllib.request.Request(
+                url, headers={"User-Agent": CLIENTFEED_UA, "Accept": "*/*"}
+            )
+            with urllib.request.urlopen(req, timeout=6) as resp:
+                xml = resp.read(1_000_000).decode("utf-8", "replace")
+        except Exception as e:
+            log(f"client feed fetch failed ({name}): {e}")
+            continue
+        n = 0
+        for entry in parse_feed(xml):
+            if n >= CLIENTFEED_PER_SOURCE:
+                break
+            if entry["link"] in seen:
+                continue
+            seen.add(entry["link"])
+            out.append({
+                "title": entry["title"], "url": entry["link"],
+                "source": name, "lang": lang, "clientfeed": True,
+                "feed_text": _strip_html(entry.get("body", ""))[:1500],
+            })
+            n += 1
+    return out
+
+
+def load_clientfeeds_cache():
+    try:
+        with open(CLIENTFEEDS_CACHE_FILE, encoding="utf-8") as f:
+            d = json.load(f) or {}
+        return (d.get("items") or [], int(d.get("ts", 0)))
+    except Exception:
+        return [], 0
+
+
+def refresh_clientfeeds_cache(feeds):
+    items = fetch_client_feeds(feeds)
+    if items:
+        atomic_write_json(
+            CLIENTFEEDS_CACHE_FILE, {"items": items, "ts": int(time.time() * 1000)}
+        )
+        log(f"client feeds refreshed: {len(items)} items from {len(feeds)} feed(s)")
+        # Summarize feed-provided body in the background. These sources' pages
+        # usually block scraping (Reddit 403s), but the RSS carries the post
+        # text, so feed_text is the summary source. Short bodies (link posts,
+        # boilerplate) fall under the summarizer's min-length gate and are
+        # skipped there. Capped per run; cached_summary dedupes across runs.
+        try:
+            tr_enabled, target_lang = translation_settings(load_config())
+            slang = target_lang if tr_enabled else "en"
+            CF_SUMMARIZE_PER_RUN = 6
+            done = 0
+            for it in items:
+                if done >= CF_SUMMARIZE_PER_RUN:
+                    break
+                ft = it.get("feed_text") or ""
+                if len(ft) >= 40 and not cached_summary(it["url"], slang):
+                    launch_summarizer(it["url"], it["title"], slang, raw_text=ft)
+                    done += 1
+        except Exception as e:
+            log(f"client feed summarize error: {e}")
+    return items
+
+
+def _spawn_clientfeeds_refresh():
+    """Refresh client feeds in a DETACHED process so the 5s news hook never
+    blocks on their network fetch."""
+    try:
+        subprocess.Popen(
+            [sys.executable, os.path.abspath(__file__), "--feeds-refresh"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            stdin=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+    except Exception as e:
+        log(f"client feeds refresh spawn failed: {e}")
+
+
+def merge_client_feeds(items, config):
+    """Prepend cached client-feed items to the pool and kick off a background
+    refresh when the cache is stale. No-op unless config['clientFeeds'] is set."""
+    feeds = (config or {}).get("clientFeeds") or []
+    if not isinstance(feeds, list) or not feeds:
+        return items
+    c_items, c_ts = load_clientfeeds_cache()
+    if c_items:
+        have = {it.get("url") for it in items if isinstance(it, dict)}
+        items = [it for it in c_items if it.get("url") not in have] + items
+    if time.time() * 1000 - c_ts > CLIENTFEEDS_TTL_SEC * 1000:
+        _spawn_clientfeeds_refresh()
+    return items
+
+
+def save_news_list(items):
+    """Persist the ordered candidate list so --nav can step through it."""
+    slim = [
+        {k: it.get(k) for k in ("title", "url", "source", "score", "comments", "lang")}
+        for it in items
+        if isinstance(it, dict) and it.get("url")
+    ]
+    atomic_write_json(NEWS_LIST_FILE, {"items": slim, "ts": int(time.time() * 1000)})
+    return slim
+
+
+def load_news_list():
+    try:
+        with open(NEWS_LIST_FILE, encoding="utf-8") as f:
+            data = json.load(f) or {}
+        items = data.get("items")
+        return items if isinstance(items, list) else []
+    except Exception:
+        return []
+
+
+def load_nav_state():
+    try:
+        with open(NAV_STATE_FILE, encoding="utf-8") as f:
+            s = json.load(f) or {}
+        return int(s.get("index", 0)), float(s.get("pinnedUntil", 0))
+    except Exception:
+        return 0, 0.0
+
+
+def save_nav_state(index, pinned_until):
+    atomic_write_json(
+        NAV_STATE_FILE, {"index": int(index), "pinnedUntil": float(pinned_until)}
+    )
+
+
+def build_record(item, translate_enabled, target_lang):
+    """Build a .current-news record for one list item using ONLY cached
+    translation + summary (no network, no spawns) so nav feels instant."""
+    summary_lang = target_lang if translate_enabled else "en"
+    original_title = item.get("title", "") or ""
+    url = item.get("url", "") or ""
+    display_title = original_title
+    if translate_enabled and item.get("lang") != target_lang:
+        cached = cached_translation(original_title, target_lang)
+        if cached:
+            display_title = cached
+    record = {
+        "title": display_title,
+        "url": url,
+        "source": item.get("source", "") or "",
+        "score": item.get("score"),
+        "comments": item.get("comments"),
+        "timestamp": int(time.time() * 1000),
+        "original_title": original_title,
+    }
+    summary = cached_summary(url, summary_lang) if url else None
+    if summary:
+        record["summary"] = summary
+    return record
+
+
+def do_nav(direction):
+    """--nav next|prev: step the global cursor over the cached list, write the
+    shared .current-news, and pin it so auto-rotation won't immediately undo it."""
+    config = load_config()
+    items = load_news_list()
+    if not items:
+        log("nav: no cached list yet")
+        return
+    index, _pinned = load_nav_state()
+    step = -1 if direction == "prev" else 1
+    index = (index + step) % len(items)
+    translate_enabled, target_lang = translation_settings(config)
+    item = items[index]
+    record = build_record(item, translate_enabled, target_lang)
+    atomic_write_json(CURRENT_NEWS_FILE, record)
+    save_nav_state(index, time.time() + NAV_PIN_SEC)
+
+    # Lazy backfill: if this item isn't summarized/translated yet, spawn the
+    # background workers. They rewrite .current-news when done (matched by
+    # original_title), so the description/translation fills in on the next
+    # status-line refresh instead of staying blank.
+    url = item.get("url", "") or ""
+    original_title = item.get("title", "") or ""
+    summary_lang = target_lang if translate_enabled else "en"
+    if url and not cached_summary(url, summary_lang):
+        launch_summarizer(url, original_title, summary_lang)
+    if (translate_enabled and item.get("lang") != target_lang
+            and not cached_translation(original_title, target_lang)):
+        launch_translator(original_title, target_lang)
+
+    # Look-ahead: warm the next items in the travel direction so flipping stays
+    # instant instead of each item starting its translation only once landed on.
+    # Titles are cheap (translate 6 ahead); summaries are heavier (2 ahead).
+    # translator.py / summarizer.py each hold a self-releasing per-item lock, so
+    # duplicate spawns (on-landing + fast repeat presses) exit cheaply.
+    for off in range(1, 7):
+        nxt = items[(index + step * off) % len(items)]
+        if not isinstance(nxt, dict):
+            continue
+        n_title = nxt.get("title") or ""
+        n_url = nxt.get("url") or ""
+        if (translate_enabled and nxt.get("lang") != target_lang
+                and n_title and not cached_translation(n_title, target_lang)):
+            launch_translator(n_title, target_lang)
+        if off <= 2 and n_url and not cached_summary(n_url, summary_lang):
+            launch_summarizer(n_url, n_title, summary_lang)
+    log(f"nav {direction} -> [{index}/{len(items)}] {record.get('title', '')[:40]}")
 
 
 def main():
@@ -493,6 +829,13 @@ def main():
         enabled = config.get("newsEnabled", True)
         api_url = config.get("apiUrl", DEFAULT_API)
 
+    # Opt-in key navigation makes news GLOBAL: every session reads the shared
+    # .current-news so cmd+ctrl+←/→ moves all panes together. When off, the
+    # per-session rotation below is left exactly as it was.
+    global_mode = nav_enabled(config)
+    if global_mode:
+        cur_news_file, last_open_file = CURRENT_NEWS_FILE, LAST_OPEN_FILE
+
     # Daily active-user heartbeat. Runs before the news enabled/rate-limit
     # gates so a still-installed client counts as active even with news off;
     # it self-throttles to once per UTC day and never blocks (detached).
@@ -515,6 +858,9 @@ def main():
     selected = resolve_sources(config, catalog)
     response = fetch_news(api_url, selected)
     items = (response or {}).get("items") or []
+    # Merge in client-fetched feed items (pulled directly from this machine) so
+    # they rotate/nav alongside server sources. No-op unless clientFeeds is set.
+    items = merge_client_feeds(items, config)
     api_pick = (response or {}).get("pick")
     if not api_pick and not items:
         log("no news received")
@@ -530,6 +876,24 @@ def main():
     # instead of locking onto the first cached one in API order. Avoid
     # re-picking the URL that was just shown.
     import random
+
+    # Global (nav) mode: persist the ordered list for --nav and, if the user
+    # navigated by hand recently, keep their pinned pick instead of rotating.
+    saved_list = None
+    if global_mode:
+        saved_list = save_news_list(items)
+        # Fill the whole list's translations in the background — BEFORE the pin
+        # check, so chatting while the nav is pinned (i.e. right after the user
+        # started browsing) still warms the cache. Otherwise flipping to any
+        # not-yet-landed item shows it untranslated until its on-landing spawn.
+        if translate_enabled:
+            prewarm_translations(saved_list, target_lang)
+        _idx, pinned_until = load_nav_state()
+        if time.time() < pinned_until:
+            log("nav pinned — keeping current item, skipping rotation")
+            pass_through()
+            return
+
     prev_url = ""
     if os.path.exists(cur_news_file):
         try:
@@ -547,14 +911,22 @@ def main():
     # OTHER live session is currently showing so two panes never collide on the
     # same headline. Degrades gracefully (see the rotatable fallback below) when
     # the candidate pool is smaller than the number of open sessions.
-    recent |= other_session_urls(cur_news_file)
+    if not global_mode:
+        # Cross-session non-overlap only applies to per-session mode; global
+        # (nav) mode intentionally shows the same item in every session.
+        recent |= other_session_urls(cur_news_file)
 
     def _not_recent(lst):
         return [it for it in lst if it.get("url") not in recent]
 
+    # Eligible for rotation = has a cached summary (instant full render) OR is a
+    # client-feed item. Client feeds (e.g. Reddit) never get a scrapable summary,
+    # but should still rotate into the status line (title-only) instead of being
+    # reachable by nav only.
     cached_candidates = [
         it for it in items
-        if isinstance(it, dict) and it.get("url") and cached_summary(it["url"], summary_lang)
+        if isinstance(it, dict) and it.get("url")
+        and (cached_summary(it["url"], summary_lang) or it.get("clientfeed"))
     ]
     # Prefer cached-summary items not shown recently; degrade gracefully so we
     # still end up with something when everything's been seen.
@@ -630,6 +1002,15 @@ def main():
         except Exception:
             pass
 
+    # Keep the nav cursor pointed at whatever auto-rotation just chose, so the
+    # next cmd+ctrl+→ steps forward from here. Unpinned (pinnedUntil=0).
+    if global_mode and saved_list is not None:
+        try:
+            idx = next(i for i, it in enumerate(saved_list) if it.get("url") == url)
+        except StopIteration:
+            idx = 0
+        save_nav_state(idx, 0)
+
     # Launch background translation if needed and not yet cached
     if title_needs_translation and display_title == original_title:
         launch_translator(original_title, target_lang)
@@ -675,8 +1056,29 @@ def main():
             f"({already_cached}/{TARGET_CACHED} cached, {summary_lang})"
         )
 
+    # Pre-warm TRANSLATIONS for the list (non-nav mode; nav mode already did this
+    # before the pin check). Previously only the picked item was translated, so
+    # rotating/navigating showed many untranslated titles until each was landed
+    # on. Cheap and cached permanently — a one-time fill over a few rotations.
+    if translate_enabled and not global_mode:
+        prewarm_translations(items, target_lang)
+
     pass_through()
 
 
 if __name__ == "__main__":
+    if len(sys.argv) >= 2 and sys.argv[1] == "--feeds-refresh":
+        try:
+            _cfg = load_config()
+            refresh_clientfeeds_cache((_cfg or {}).get("clientFeeds") or [])
+        except Exception as e:
+            log(f"client feeds refresh error: {e}")
+        sys.exit(0)
+    if len(sys.argv) >= 2 and sys.argv[1] == "--nav":
+        _direction = sys.argv[2] if len(sys.argv) >= 3 else "next"
+        try:
+            do_nav("prev" if _direction == "prev" else "next")
+        except Exception as e:
+            log(f"nav error: {e}")
+        sys.exit(0)
     main()

--- a/plugin/hooks/summarizer.py
+++ b/plugin/hooks/summarizer.py
@@ -573,6 +573,9 @@ def main():
     target_lang = sys.argv[1]
     url = sys.argv[2]
     original_title = sys.argv[3]
+    # Optional feed-provided body (Reddit/Mastodon/…), used as the summary
+    # source when the page can't be scraped.
+    raw_text_arg = sys.argv[4] if len(sys.argv) >= 5 else ""
 
     if not url or not original_title:
         sys.exit(0)
@@ -622,6 +625,10 @@ def main():
             # Prefer real body text (avoids "1-line og padded to 3
             # sentences"); fall back to the meta description.
             raw_desc = fetch_article_text(target) or fetch_meta_description(target)
+        # Feed-provided body fallback (Reddit/Mastodon/…): use it when the page
+        # yields nothing scrapable. Short bodies are caught by the length gate below.
+        if (not raw_desc or is_likely_boilerplate(raw_desc)) and len(raw_text_arg) >= 40:
+            raw_desc = raw_text_arg
         if not raw_desc or is_likely_boilerplate(raw_desc):
             write_status(url, "error")
             return

--- a/plugin/hud/claudenews-hud.mjs
+++ b/plugin/hud/claudenews-hud.mjs
@@ -72,9 +72,9 @@ let sourcesConfigured = false;
 let navEnabled = false;
 // Summary line color (SGR params). Default to a readable light gray instead of
 // the faint/dim attribute (\x1b[2m), which many terminals render too low-contrast
-// to read. Override via config "summaryColor" (e.g. "37" plain white, "38;5;245"
-// dimmer gray, "38;5;252" brighter). Validated to digits/semicolons only.
-let summaryColor = "38;5;250";
+// to read. Override via config "summaryColor" (e.g. "37" plain white, "38;5;250"
+// lighter gray, "38;5;252" brighter). Validated to digits/semicolons only.
+let summaryColor = "38;5;245";
 if (existsSync(CONFIG_FILE)) {
   try {
     const cfg = JSON.parse(readFileSync(CONFIG_FILE, "utf-8"));

--- a/plugin/hud/claudenews-hud.mjs
+++ b/plugin/hud/claudenews-hud.mjs
@@ -85,6 +85,9 @@ let maxCols = 120; // safe default — Claude Code's statusline doesn't pass wid
 let userOverrodeMaxCols = false;
 let sourcesConfigured = false;
 let navEnabled = false;
+// Human-readable nav key combo shown in the rotating hint. Mirrors the binding
+// in claudenews-nav.lua (config.json -> navKeys); defaults to ctrl+shift+←/→.
+let navCombo = "ctrl+shift+←/→";
 // Summary line color (SGR params). Default to a readable light gray instead of
 // the faint/dim attribute (\x1b[2m), which many terminals render too low-contrast
 // to read. Override via config "summaryColor" (e.g. "37" plain white, "38;5;250"
@@ -95,6 +98,7 @@ if (existsSync(CONFIG_FILE)) {
     const cfg = JSON.parse(readFileSync(CONFIG_FILE, "utf-8"));
     sourcesConfigured = cfg.sourcesConfigured === true;
     navEnabled = cfg.navEnabled === true;
+    navCombo = formatNavCombo(cfg.navKeys);
     if (typeof cfg.summaryColor === "string" && /^[0-9;]+$/.test(cfg.summaryColor)) {
       summaryColor = cfg.summaryColor;
     }
@@ -414,9 +418,9 @@ if (existsSync(newsFilePath)) {
         // can actually drive (never advertise a feature that can't work here)
         // and only while nav is still off; once on, show the shortcut instead.
         if (navEnabled) {
-          pool = ["ctrl+shift+←/→ to browse news", ...pool];
+          pool = [`${navCombo} to browse news`, ...pool];
         } else if (terminalSupportsNav()) {
-          pool = ["/claudenews:nav on — browse news with ctrl+shift+←/→", ...pool];
+          pool = [`/claudenews:nav on — browse news with ${navCombo}`, ...pool];
         }
         const guide =
           pool[Math.floor(Date.now() / GUIDE_ROTATE_MS) % pool.length];
@@ -529,6 +533,31 @@ function visibleCols(line) {
   let c = 0;
   for (const ch of visible) c += charCols(ch.codePointAt(0));
   return c;
+}
+
+// Format the configured nav key combo (config.json -> navKeys) into the hint
+// string, mirroring the binding in claudenews-nav.lua. Falls back to the default
+// ctrl+shift+←/→ for any missing/invalid field.
+function formatNavCombo(nk) {
+  const DEF = "ctrl+shift+←/→";
+  if (!nk || typeof nk !== "object") return DEF;
+  const alias = { control: "ctrl", command: "cmd", option: "alt", opt: "alt" };
+  const order = ["ctrl", "shift", "alt", "cmd"]; // ctrl+shift first → matches DEF
+  const have = new Set();
+  if (Array.isArray(nk.modifiers)) {
+    for (const m of nk.modifiers) {
+      const k = String(m).toLowerCase();
+      const norm = alias[k] || k;
+      if (order.includes(norm)) have.add(norm);
+    }
+  }
+  const mods = order.filter((m) => have.has(m));
+  if (!mods.length) return DEF; // empty/invalid mods → bare arrows are never bound
+  const sym = (name, fallback) => {
+    const k = typeof name === "string" ? name.toLowerCase() : "";
+    return { left: "←", right: "→", up: "↑", down: "↓" }[k] || k || fallback;
+  };
+  return `${mods.join("+")}+${sym(nk.prev, "←")}/${sym(nk.next, "→")}`;
 }
 
 // Best-effort: is this a terminal whose focused pane's tty the Hammerspoon nav

--- a/plugin/hud/claudenews-hud.mjs
+++ b/plugin/hud/claudenews-hud.mjs
@@ -232,6 +232,38 @@ function ttyCols(dev) {
   return null;
 }
 
+// Background agents (Claude Code's daemon-spawned sessions, e.g. when attached
+// via `claude agents`) have no controlling tty and no TERM_PROGRAM/
+// ITERM_SESSION_ID — so neither the tty walk nor the per-terminal probes can
+// see the display width. But Claude Code launches each agent's pty-host with
+// the display terminal's size baked into argv:
+//   claude --bg-pty-host <sock> <cols> <rows> -- ...
+// Recover <cols> from the nearest such ancestor. (Set at attach time; a later
+// resize isn't reflected until the agent is re-attached — still far better than
+// the static fallback.)
+function backgroundAgentCols() {
+  let pid = process.ppid;
+  for (let i = 0; i < 8 && pid > 1; i++) {
+    try {
+      const r = spawnSync("ps", ["-o", "ppid=", "-o", "command=", "-p", String(pid)], {
+        encoding: "utf-8",
+        timeout: 300,
+      });
+      const m = (r.stdout || "").trim().match(/^(\d+)\s+(.*)$/);
+      if (!m) break;
+      const dims = m[2].match(/--bg-pty-host\s+\S+\s+(\d+)\s+(\d+)/);
+      if (dims) {
+        const c = parseInt(dims[1], 10);
+        if (Number.isFinite(c) && c > 20) return c;
+      }
+      pid = parseInt(m[1], 10) || 0;
+    } catch {
+      break;
+    }
+  }
+  return null;
+}
+
 function detectTerminalCols() {
   if (process.env.CMUX_SOCKET && process.env.CMUX_WORKSPACE_ID) {
     try {
@@ -256,6 +288,10 @@ function detectTerminalCols() {
     const c = ttyCols(ttyDev);
     if (c) return c;
   }
+  // No controlling tty (background/daemon agent): recover the display width
+  // from the pty-host argv.
+  const bgCols = backgroundAgentCols();
+  if (bgCols) return bgCols;
   // Only query tmux when actually running inside one — otherwise tmux would
   // report some unrelated session's width.
   if (process.env.TMUX) {

--- a/plugin/hud/claudenews-hud.mjs
+++ b/plugin/hud/claudenews-hud.mjs
@@ -301,9 +301,9 @@ if (existsSync(newsFilePath)) {
         // can actually drive (never advertise a feature that can't work here)
         // and only while nav is still off; once on, show the shortcut instead.
         if (navEnabled) {
-          pool = ["ctrl+←/→ to browse news", ...pool];
+          pool = ["ctrl+shift+←/→ to browse news", ...pool];
         } else if (terminalSupportsNav()) {
-          pool = ["/claudenews:nav on — browse news with ctrl+←/→", ...pool];
+          pool = ["/claudenews:nav on — browse news with ctrl+shift+←/→", ...pool];
         }
         const guide =
           pool[Math.floor(Date.now() / GUIDE_ROTATE_MS) % pool.length];

--- a/plugin/hud/claudenews-hud.mjs
+++ b/plugin/hud/claudenews-hud.mjs
@@ -120,6 +120,16 @@ if (!userOverrodeMaxCols) {
   }
 }
 
+// Reserve a small right margin so no rendered row ever reaches the full
+// terminal width. Claude Code's status-line renderer lays each row into a
+// fixed-width screen buffer and clips a row that fills the last column —
+// replacing the final glyph with "…". That looked like a stray ellipsis
+// mid-summary (e.g. "효율적으…" with the real next line below). Keeping every
+// line strictly narrower than the detected width avoids it, and also absorbs
+// the ±1 col our width count can differ from CC's for an ambiguous-width glyph
+// like the "↳" summary marker.
+maxCols = Math.max(20, maxCols - 2);
+
 // Cache the detected width so the (possibly expensive, e.g. iTerm AppleScript)
 // probe runs at most once per TTL instead of on EVERY status-line render. This
 // lets refreshInterval go low without paying osascript each frame; a terminal

--- a/plugin/hud/claudenews-hud.mjs
+++ b/plugin/hud/claudenews-hud.mjs
@@ -57,7 +57,7 @@ const GUIDES_EVERGREEN = [
   "/claudenews:list to see & pick news sources",
   "/claudenews:translate ko to set language",
   "/claudenews:feedback <msg> to send feedback",
-  "add your own RSS/Reddit feeds in ~/.claudenews/config.json",
+  "ask Claude to add r/<sub> as a feed",
 ];
 const GUIDE_PICK_SOURCES = "/claudenews:list to pick your news sources";
 

--- a/plugin/hud/claudenews-hud.mjs
+++ b/plugin/hud/claudenews-hud.mjs
@@ -57,6 +57,7 @@ const GUIDES_EVERGREEN = [
   "/claudenews:list to see & pick news sources",
   "/claudenews:translate ko to set language",
   "/claudenews:feedback <msg> to send feedback",
+  "add your own RSS/Reddit feeds in ~/.claudenews/config.json",
 ];
 const GUIDE_PICK_SOURCES = "/claudenews:list to pick your news sources";
 

--- a/plugin/hud/claudenews-hud.mjs
+++ b/plugin/hud/claudenews-hud.mjs
@@ -29,15 +29,29 @@ const GUIDES_CACHE = join(HOME, ".claudenews/.guides-cache.json");
 // so the label tracks updates without editing this file every release.
 function detectVersion() {
   try {
-    const dir = join(HOME, ".claude/plugins/cache/claudenews/claudenews");
-    const vers = readdirSync(dir).filter((v) => /^\d+\.\d+\.\d+/.test(v));
-    if (!vers.length) return "";
-    vers.sort((a, b) => {
-      const pa = a.split(".").map(Number);
-      const pb = b.split(".").map(Number);
-      return pb[0] - pa[0] || pb[1] - pa[1] || pb[2] - pa[2];
-    });
-    return vers[0];
+    // Marketplace-agnostic: scan cache/<marketplace>/claudenews/<ver> and take
+    // the newest across ALL marketplaces (matches the launcher), so a stale
+    // install under a different marketplace name can't pin the label to an old
+    // version.
+    const cacheRoot = join(HOME, ".claude/plugins/cache");
+    const cmp = (a, b) => {
+      const A = a.split(".").map(Number);
+      const B = b.split(".").map(Number);
+      return B[0] - A[0] || B[1] - A[1] || B[2] - A[2];
+    };
+    let best = "";
+    for (const mp of readdirSync(cacheRoot)) {
+      let vers;
+      try {
+        vers = readdirSync(join(cacheRoot, mp, "claudenews")).filter((v) =>
+          /^\d+\.\d+\.\d+/.test(v)
+        );
+      } catch {
+        continue;
+      }
+      for (const v of vers) if (!best || cmp(v, best) < 0) best = v;
+    }
+    return best;
   } catch {
     return "";
   }

--- a/plugin/hud/claudenews-hud.mjs
+++ b/plugin/hud/claudenews-hud.mjs
@@ -189,6 +189,49 @@ function cachedParentOutput(parentCmd) {
   return out;
 }
 
+// Resolve the controlling terminal of the Claude Code process that spawned this
+// status line. The status-line child itself usually has no controlling TTY, but
+// its parent (Claude Code) does — walk up a few ancestors until one is attached
+// to a real terminal device. Returns "/dev/ttysNNN" (or "/dev/pts/N") or null.
+function controllingTtyDevice() {
+  let pid = process.ppid;
+  for (let depth = 0; depth < 6 && pid > 1; depth++) {
+    try {
+      const r = spawnSync("ps", ["-o", "tty=", "-o", "ppid=", "-p", String(pid)], {
+        encoding: "utf-8",
+        timeout: 300,
+      });
+      const parts = (r.stdout || "").trim().split(/\s+/);
+      const tty = parts[0] || "";
+      const ppid = parseInt(parts[1], 10);
+      if (/^(tty|pts)/.test(tty)) return "/dev/" + tty;
+      pid = Number.isFinite(ppid) ? ppid : 0;
+    } catch {
+      break;
+    }
+  }
+  return null;
+}
+
+// Read the live window size straight from a tty device. This is the kernel's
+// TIOCGWINSZ — the exact column count the terminal renders to — so it's accurate
+// for every terminal (iTerm2, Terminal.app, WezTerm, kitty, Ghostty, Alacritty,
+// VS Code) and for tmux panes, and never goes stale the way matching on
+// ITERM_SESSION_ID can (that env var survives session restoration while the
+// session's identity changes underneath it).
+function ttyCols(dev) {
+  if (!/^\/dev\/[A-Za-z0-9/]+$/.test(dev)) return null;
+  try {
+    const r = spawnSync("sh", ["-c", `stty size < ${dev} 2>/dev/null`], {
+      encoding: "utf-8",
+      timeout: 300,
+    });
+    const n = parseInt((r.stdout || "").trim().split(/\s+/)[1], 10);
+    if (Number.isFinite(n) && n > 0) return n;
+  } catch {}
+  return null;
+}
+
 function detectTerminalCols() {
   if (process.env.CMUX_SOCKET && process.env.CMUX_WORKSPACE_ID) {
     try {
@@ -203,6 +246,15 @@ function detectTerminalCols() {
         if (focused && typeof focused.columns === "number") return focused.columns;
       }
     } catch {}
+  }
+  // Primary for non-multiplexed terminals: read the real window size from the
+  // controlling tty of the Claude Code process that spawned us. Terminal-agnostic
+  // and immune to a stale ITERM_SESSION_ID, so it supersedes the per-terminal
+  // probes below (which remain as fallbacks for sandboxes where ps/stty fail).
+  const ttyDev = controllingTtyDevice();
+  if (ttyDev) {
+    const c = ttyCols(ttyDev);
+    if (c) return c;
   }
   // Only query tmux when actually running inside one — otherwise tmux would
   // report some unrelated session's width.

--- a/plugin/hud/claudenews-hud.mjs
+++ b/plugin/hud/claudenews-hud.mjs
@@ -12,7 +12,7 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -69,23 +69,27 @@ let parentOutput = "";
 let maxCols = 120; // safe default — Claude Code's statusline doesn't pass width
 let userOverrodeMaxCols = false;
 let sourcesConfigured = false;
+let navEnabled = false;
+// Summary line color (SGR params). Default to a readable light gray instead of
+// the faint/dim attribute (\x1b[2m), which many terminals render too low-contrast
+// to read. Override via config "summaryColor" (e.g. "37" plain white, "38;5;245"
+// dimmer gray, "38;5;252" brighter). Validated to digits/semicolons only.
+let summaryColor = "38;5;250";
 if (existsSync(CONFIG_FILE)) {
   try {
     const cfg = JSON.parse(readFileSync(CONFIG_FILE, "utf-8"));
     sourcesConfigured = cfg.sourcesConfigured === true;
+    navEnabled = cfg.navEnabled === true;
+    if (typeof cfg.summaryColor === "string" && /^[0-9;]+$/.test(cfg.summaryColor)) {
+      summaryColor = cfg.summaryColor;
+    }
     if (typeof cfg.maxStatuslineCols === "number" && cfg.maxStatuslineCols > 20) {
       maxCols = cfg.maxStatuslineCols;
       userOverrodeMaxCols = true;
     }
     const parentCmd = (cfg.parentStatusLine || "").trim();
     if (parentCmd) {
-      const result = spawnSync(parentCmd, [], {
-        shell: true,
-        input: stdinData,
-        encoding: "utf-8",
-        timeout: 3000,
-      });
-      parentOutput = (result.stdout || "").trimEnd();
+      parentOutput = cachedParentOutput(parentCmd);
     }
   } catch {}
 }
@@ -95,10 +99,79 @@ if (existsSync(CONFIG_FILE)) {
 // environment: cmux RPC → tmux display-message → stty via /dev/tty. Each
 // channel either works in its environment or fails fast.
 if (!userOverrodeMaxCols) {
-  const detected = detectTerminalCols();
+  const detected = detectTerminalColsCached();
   if (detected && detected > 20) {
     maxCols = detected;
   }
+}
+
+// Cache the detected width so the (possibly expensive, e.g. iTerm AppleScript)
+// probe runs at most once per TTL instead of on EVERY status-line render. This
+// lets refreshInterval go low without paying osascript each frame; a terminal
+// resize is reflected within the TTL.
+// Stable per-pane cache key. Terminal width is PER-PANE, so the width cache
+// must be too: keying by the Claude Code session id (1:1 with a pane,
+// terminal-agnostic, always present on stdin) — falling back to the terminal's
+// own pane id — stops panes of different widths from clobbering one shared
+// cache file every TTL, which made the summary re-wrap to a different line
+// count each render (the status bar visibly "flickered" between N and N+1 lines).
+function paneCacheKey() {
+  try {
+    const sid = (JSON.parse(stdinData) || {}).session_id;
+    if (sid) return String(sid).replace(/[^A-Za-z0-9_-]/g, "").slice(0, 64);
+  } catch {}
+  const pane = process.env.ITERM_SESSION_ID || process.env.TMUX_PANE || "";
+  return pane.replace(/[^A-Za-z0-9_-]/g, "").slice(0, 64) || "default";
+}
+
+function detectTerminalColsCached() {
+  const CACHE = join(HOME, `.claudenews/.cols-cache.${paneCacheKey()}`);
+  const TTL_MS = 5000;
+  try {
+    const raw = JSON.parse(readFileSync(CACHE, "utf-8"));
+    if (raw && typeof raw.cols === "number" && Date.now() - raw.ts < TTL_MS) {
+      return raw.cols;
+    }
+  } catch {}
+  const cols = detectTerminalCols();
+  if (cols && cols > 20) {
+    try {
+      writeFileSync(CACHE, JSON.stringify({ cols, ts: Date.now() }));
+    } catch {}
+  }
+  return cols;
+}
+
+// The upstream statusline (e.g. the OMC HUD) is by far the costliest part of a
+// render — ~0.17s vs ~0.03s for the news line — so re-running it on EVERY frame
+// is what makes a low refreshInterval expensive. Cache its stdout per-session
+// for a short TTL: the news line still re-renders every frame (so key-nav feels
+// instant) while the upstream line refreshes only every TTL. Keyed per-session
+// because the upstream output is session-specific (model / dir / context); a
+// shared file would show one session's HUD in another. Transient failures
+// (empty stdout / timeout) are NOT cached so the next frame retries.
+function cachedParentOutput(parentCmd) {
+  const CACHE = join(HOME, `.claudenews/.parent-cache.${paneCacheKey()}`);
+  const TTL_MS = 2000;
+  try {
+    const raw = JSON.parse(readFileSync(CACHE, "utf-8"));
+    if (raw && typeof raw.out === "string" && Date.now() - raw.ts < TTL_MS) {
+      return raw.out;
+    }
+  } catch {}
+  const result = spawnSync(parentCmd, [], {
+    shell: true,
+    input: stdinData,
+    encoding: "utf-8",
+    timeout: 3000,
+  });
+  const out = (result.stdout || "").trimEnd();
+  if (out) {
+    try {
+      writeFileSync(CACHE, JSON.stringify({ out, ts: Date.now() }));
+    } catch {}
+  }
+  return out;
 }
 
 function detectTerminalCols() {
@@ -173,8 +246,10 @@ end tell`
 // multiple panes/sessions don't all show the same headline. The status line
 // receives the session id on stdin; fall back to the shared global file when
 // it's missing (older Claude Code) or that session hasn't rotated yet.
+// In nav mode news is global (every session shows the same item), so read the
+// shared file directly. Otherwise prefer this session's own rotated item.
 let newsFilePath = NEWS_FILE;
-{
+if (!navEnabled) {
   let sid = "";
   try {
     sid = (JSON.parse(stdinData) || {}).session_id || "";
@@ -200,13 +275,12 @@ if (existsSync(newsFilePath)) {
         ? ` \x1b[90m💬${raw.comments}\x1b[0m`
         : "";
 
-      // Only wrap the title in an OSC 8 hyperlink when the terminal can
-      // actually open it — otherwise the link is invisible/unreachable.
-      const clickable = terminalSupportsLinks();
-      const titleStyled =
-        clickable && url
-          ? `\x1b]8;;${url}\x07\x1b[37;4m${title}\x1b[0m\x1b]8;;\x07`
-          : `\x1b[37m${title}\x1b[0m`;
+      // Title is always an OSC 8 hyperlink so a click / ⌘-click opens the
+      // article. Terminals without OSC 8 support just render the plain title
+      // (the escape is invisible), so this is safe everywhere.
+      const titleStyled = url
+        ? `\x1b]8;;${url}\x07\x1b[37;4m${title}\x1b[0m\x1b]8;;\x07`
+        : `\x1b[37m${title}\x1b[0m`;
 
       newsLine =
         `\x1b[1m${FEED_LABEL}\x1b[0m ` +
@@ -216,32 +290,25 @@ if (existsSync(newsFilePath)) {
         scoreStr +
         commentsStr;
 
-      const usedCols = visibleCols(newsLine);
-
-      if (!clickable && url) {
-        // Link isn't clickable here (plain terminal, or tmux stripping OSC 8),
-        // so show a shortened, copyable URL right-aligned at the end of line 1
-        // in place of the rotating guide.
-        const avail = maxCols - usedCols - 2;
-        if (avail >= 8) {
-          const shortUrl = shortenUrl(url, Math.min(48, avail));
-          let su = 0;
-          for (const ch of shortUrl) su += charCols(ch.codePointAt(0));
-          const gap = maxCols - usedCols - su;
-          if (shortUrl && gap >= 1) {
-            newsLine += " ".repeat(gap) + `\x1b[2;4m${shortUrl}\x1b[0m`;
-          }
-        }
-      } else {
-        // Rotating usage guide (server-driven, built-in fallback) appended to
-        // the END of line 1 — only if it still fits so the line never wraps.
+      // Rotating usage guide appended to the END of line 1 (server-driven,
+      // built-in fallback) — only if it still fits so the line never wraps.
+      {
         const evergreen = loadServerGuides() || GUIDES_EVERGREEN;
-        const pool = sourcesConfigured
+        let pool = sourcesConfigured
           ? evergreen
           : [GUIDE_PICK_SOURCES, ...evergreen];
+        // Key-navigation tips. The activation tip appears ONLY on terminals we
+        // can actually drive (never advertise a feature that can't work here)
+        // and only while nav is still off; once on, show the shortcut instead.
+        if (navEnabled) {
+          pool = ["ctrl+←/→ to browse news", ...pool];
+        } else if (terminalSupportsNav()) {
+          pool = ["/claudenews:nav on — browse news with ctrl+←/→", ...pool];
+        }
         const guide =
           pool[Math.floor(Date.now() / GUIDE_ROTATE_MS) % pool.length];
         const HINT = "  " + guide;
+        const usedCols = visibleCols(newsLine);
         let hintCols = 0;
         for (const ch of HINT) hintCols += charCols(ch.codePointAt(0));
         if (usedCols + hintCols <= maxCols) {
@@ -260,9 +327,9 @@ if (existsSync(newsFilePath)) {
         const wrapped = wrapCols(summary, innerWidth, 12);
         wrapped.forEach((ln, i) => {
           if (i === 0) {
-            newsLine += `\n\x1b[90m       ↳\x1b[0m \x1b[2m${ln}\x1b[0m`;
+            newsLine += `\n\x1b[90m       ↳\x1b[0m \x1b[${summaryColor}m${ln}\x1b[0m`;
           } else {
-            newsLine += `\n         \x1b[2m${ln}\x1b[0m`;
+            newsLine += `\n         \x1b[${summaryColor}m${ln}\x1b[0m`;
           }
         });
       }
@@ -326,7 +393,7 @@ function wrapCols(s, width, maxLines) {
   return kept;
 }
 
-// ── server-driven guides + link handling ───────────────────────────────────
+// ── server-driven guides ────────────────────────────────────────────────────
 function loadServerGuides() {
   try {
     const raw = JSON.parse(readFileSync(GUIDES_CACHE, "utf-8"));
@@ -351,43 +418,21 @@ function visibleCols(line) {
   return c;
 }
 
-// Best-effort: can the user actually open a link here (OSC 8 hyperlink or
-// Cmd/Ctrl-click)? Conservative — unknown ⇒ false, so we fall back to printing
-// a visible URL. tmux/screen strip OSC 8 hyperlinks by default.
-function terminalSupportsLinks() {
-  if (process.env.TMUX) return false;
+// Best-effort: is this a terminal whose focused pane's tty the Hammerspoon nav
+// tap can resolve (to confirm Claude Code is focused before acting)? Used only
+// to decide whether to advertise /claudenews:nav. Conservative — tmux/ssh and
+// unknown/unsupported terminals (Ghostty<1.4, Warp, Alacritty, VS Code) ⇒ false
+// so we never suggest the feature where it can't work.
+function terminalSupportsNav() {
+  if (process.env.TMUX) return false; // tmux hides the outer terminal
   const term = process.env.TERM || "";
   if (term.startsWith("screen") || term.startsWith("tmux")) return false;
   const prog = process.env.TERM_PROGRAM || "";
-  const KNOWN = [
-    "iTerm.app", "Apple_Terminal", "vscode", "WezTerm",
-    "ghostty", "Hyper", "Tabby", "rio",
-  ];
-  if (KNOWN.includes(prog)) return true;
-  if (term.includes("kitty") || term.includes("wezterm")) return true;
-  if (process.env.WT_SESSION) return true; // Windows Terminal
-  if (process.env.KONSOLE_VERSION) return true;
-  if (Number(process.env.VTE_VERSION || 0) >= 5000) return true; // VTE ≥ 0.50
-  return false;
-}
-
-// Compact a URL to fit `budget` display cols: drop scheme + "www." + trailing
-// slash, then truncate with a trailing ….
-function shortenUrl(url, budget) {
-  if (budget < 8) return "";
-  const s = url
-    .replace(/^https?:\/\//, "")
-    .replace(/^www\./, "")
-    .replace(/\/+$/, "");
-  let cols = 0;
-  let out = "";
-  for (const ch of s) {
-    const w = charCols(ch.codePointAt(0));
-    if (cols + w > budget - 1) return out + "…";
-    out += ch;
-    cols += w;
+  if (prog === "iTerm.app" || prog === "Apple_Terminal" || prog === "WezTerm") {
+    return true;
   }
-  return out;
+  if (process.env.KITTY_WINDOW_ID || term.includes("kitty")) return true;
+  return false;
 }
 
 if (parentOutput) {

--- a/plugin/hud/launcher.mjs
+++ b/plugin/hud/launcher.mjs
@@ -6,6 +6,10 @@
  * updates take effect with no /claudenews:setup re-run — the launcher
  * never needs to change.
  *
+ * Marketplace-agnostic: scans every cache/<marketplace>/claudenews/<ver>
+ * so installs from a renamed/forked marketplace (e.g. claudenews-pr) work
+ * too — not just the canonical "claudenews" marketplace.
+ *
  * Fails safe: if no cached hud is found it prints a blank line so the
  * status line is never broken.
  */
@@ -14,22 +18,31 @@ import { spawnSync } from "node:child_process";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-const base = join(homedir(), ".claude/plugins/cache/claudenews/claudenews");
+const cacheRoot = join(homedir(), ".claude/plugins/cache");
+
+const cmp = (a, b) => {
+  const A = a.split(".").map(Number);
+  const B = b.split(".").map(Number);
+  return B[0] - A[0] || B[1] - A[1] || B[2] - A[2];
+};
 
 let target = null;
+let best = null;
 try {
-  const vers = readdirSync(base)
-    .filter((v) => /^\d+\.\d+\.\d+/.test(v))
-    .sort((a, b) => {
-      const A = a.split(".").map(Number);
-      const B = b.split(".").map(Number);
-      return B[0] - A[0] || B[1] - A[1] || B[2] - A[2];
-    });
-  for (const v of vers) {
-    const p = join(base, v, "hud/claudenews-hud.mjs");
-    if (existsSync(p)) {
-      target = p;
-      break;
+  for (const mp of readdirSync(cacheRoot)) {
+    const pluginBase = join(cacheRoot, mp, "claudenews");
+    let vers;
+    try {
+      vers = readdirSync(pluginBase).filter((v) => /^\d+\.\d+\.\d+/.test(v));
+    } catch {
+      continue;
+    }
+    for (const v of vers) {
+      const p = join(pluginBase, v, "hud/claudenews-hud.mjs");
+      if (existsSync(p) && (best === null || cmp(v, best) < 0)) {
+        best = v;
+        target = p;
+      }
     }
   }
 } catch {}

--- a/plugin/hud/nav-launcher.sh
+++ b/plugin/hud/nav-launcher.sh
@@ -4,16 +4,27 @@
 # and runs show-news.py in --nav mode, so the path the Hammerspoon tap calls
 # never changes across plugin updates.
 #
+# Marketplace-agnostic: scans every cache/<marketplace>/claudenews/<ver> so an
+# install from a renamed/forked marketplace (e.g. claudenews-pr) works too —
+# not just the canonical "claudenews" marketplace.
+#
 # Usage: claudenews-nav next|prev
-BASE="$HOME/.claude/plugins/cache/claudenews/claudenews"
-DIR="$(ls -1 "$BASE" 2>/dev/null \
-  | grep -E '^[0-9]+\.[0-9]+\.[0-9]+' \
-  | sort -t. -k1,1n -k2,2n -k3,3n | tail -1)"
-[ -n "$DIR" ] || exit 0
+CACHE="$HOME/.claude/plugins/cache"
+ver_ge() { # true if $1 >= $2 (semver-ish numeric compare)
+  [ "$(printf '%s\n%s\n' "$1" "$2" | sort -t. -k1,1n -k2,2n -k3,3n | tail -1)" = "$1" ]
+}
+BEST=""; BESTPATH=""
+for f in "$CACHE"/*/claudenews/*/hooks/show-news.py; do
+  [ -f "$f" ] || continue
+  ver="$(basename "$(dirname "$(dirname "$f")")")"
+  case "$ver" in [0-9]*.[0-9]*.[0-9]*) ;; *) continue ;; esac
+  if [ -z "$BEST" ] || ver_ge "$ver" "$BEST"; then BEST="$ver"; BESTPATH="$f"; fi
+done
+[ -n "$BESTPATH" ] || exit 0
 # Pick a real python3 (this machine's /usr/bin/python3 may be a CLT stub, and
 # Hammerspoon's hs.task runs with a minimal PATH).
 PY=python3
 for c in /opt/homebrew/bin/python3 /usr/local/bin/python3; do
   [ -x "$c" ] && PY="$c" && break
 done
-exec "$PY" "$BASE/$DIR/hooks/show-news.py" --nav "${1:-next}"
+exec "$PY" "$BESTPATH" --nav "${1:-next}"

--- a/plugin/hud/nav-launcher.sh
+++ b/plugin/hud/nav-launcher.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Stable claudenews nav launcher. Installed to ~/.claude/hud/claudenews-nav by
+# `/claudenews:nav on`. Resolves the NEWEST installed plugin version at runtime
+# and runs show-news.py in --nav mode, so the path the Hammerspoon tap calls
+# never changes across plugin updates.
+#
+# Usage: claudenews-nav next|prev
+BASE="$HOME/.claude/plugins/cache/claudenews/claudenews"
+DIR="$(ls -1 "$BASE" 2>/dev/null \
+  | grep -E '^[0-9]+\.[0-9]+\.[0-9]+' \
+  | sort -t. -k1,1n -k2,2n -k3,3n | tail -1)"
+[ -n "$DIR" ] || exit 0
+# Pick a real python3 (this machine's /usr/bin/python3 may be a CLT stub, and
+# Hammerspoon's hs.task runs with a minimal PATH).
+PY=python3
+for c in /opt/homebrew/bin/python3 /usr/local/bin/python3; do
+  [ -x "$c" ] && PY="$c" && break
+done
+exec "$PY" "$BASE/$DIR/hooks/show-news.py" --nav "${1:-next}"

--- a/web/src/app/api/guides/route.ts
+++ b/web/src/app/api/guides/route.ts
@@ -17,6 +17,7 @@ const DEFAULTS: string[] = [
   "/claudenews:list to see & pick news sources",
   "/claudenews:translate ko to set language",
   "/claudenews:feedback <msg> to send feedback",
+  "add your own RSS/Reddit feeds in ~/.claudenews/config.json",
 ];
 
 const MAX_GUIDES = 20;

--- a/web/src/app/api/guides/route.ts
+++ b/web/src/app/api/guides/route.ts
@@ -17,7 +17,7 @@ const DEFAULTS: string[] = [
   "/claudenews:list to see & pick news sources",
   "/claudenews:translate ko to set language",
   "/claudenews:feedback <msg> to send feedback",
-  "add your own RSS/Reddit feeds in ~/.claudenews/config.json",
+  "ask Claude to add r/<sub> as a feed",
 ];
 
 const MAX_GUIDES = 20;


### PR DESCRIPTION
## Summary
Bundles this session's work into v0.22.0.

### Opt-in keyboard navigation (`/claudenews:nav on`)
- Hammerspoon `ctrl+shift+←/→` steps the **global** news prev/next.
- Gated to a frontmost supported terminal (iTerm2/Terminal/WezTerm/kitty) via an instant bundle-id check — `ctrl+shift+arrow` is unused in terminal line-editing, so no per-press AppleScript/tty probe is needed.
- Autorepeat suppressed (one step per press) and 150ms debounced.
- When nav is on, news is **global**: every session shows the same item so all panes move together.

### Client-fetched feed sources (generic transport)
- `config.clientFeeds: [{name,url,lang}]` are fetched **directly from the client machine** (browser UA), parsed by a namespace-agnostic RSS 2.0 + Atom parser, cached, and merged into the pool — flowing through rotation / nav / translation / summary like any server source. No source-specific code.
- Enables feeds the server's datacenter IP can't reach: e.g. Reddit 403s `.json` and server IPs, but `www.reddit.com/r/<sub>/.rss` + a browser UA works from a normal machine.
- Feed-provided body (`<content>`/`<description>`) is summarized when the page can't be scraped; client-feed items are rotation-eligible (title-only) rather than nav-only.

### Faster background translations / summaries
- Disable MCP servers for background `claude --print` (`--strict-mcp-config` + empty config, prompt on stdin): **~15s → ~3s** by skipping MCP cold start.
- Translation prewarm (per Stop) + nav look-ahead; dedup via the workers' own self-releasing per-item locks.

### Status line
- Per-pane width cache + per-session OMC parent-output cache: fixes the 3↔4 line flicker (panes of different widths no longer clobber one shared cache) and cuts render cost so a low `refreshInterval` stays cheap.
- Configurable `summaryColor` (default readable gray) instead of faint/dim.
- HackerNews title is an OSC 8 hyperlink again (clickable).

## Notes
- Version set to **0.22.0**. The maintainer's separate WIP (`web/ping`, heartbeat, plugin.json) is intentionally NOT included; reconcile the version if needed.
- All Python/JS/Lua syntax-checked.

## Test
- E2E: fresh install from marketplace → `/claudenews:setup` → `/claudenews:nav on` → ctrl+shift+←/→ steps news; add a `clientFeeds` Reddit entry and confirm it rotates in.
