### PR TITLE
chore: bump version to 0.23.0

### DIFF
--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claudenews",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "DevFeed — HackerNews and GitHub Trending in your status line while Claude Code thinks",
   "author": {
     "name": "bhpark1013",


### PR DESCRIPTION
Bumps plugin version 0.22.0 → 0.23.0 to cover the work added after the original 0.22.0 commit: configurable nav key combo (navKeys, new feature), terminal-width detection fixes (controlling tty + bg-agent pty-host width + full-width clip margin), self-completing nav on, and summaryColor 245 default. Needed so /claudenews:update picks up the new build.

https://claude.ai/code/session_01UhkPdZhbLbErwwjWUcFygy