### PR TITLE
docs: note the key-nav combo is remappable via navKeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ If you'd rather step through items yourself, turn on key navigation:
 ```
 
 - **`ctrl+shift+→`** next · **`ctrl+shift+←`** previous
+- **Remap the keys:** set `navKeys` in `~/.claudenews/config.json` (any
+  `ctrl`/`shift`/`cmd`/`alt` combo + prev/next keys), then rerun
+  `/claudenews:nav on` — see **Power-user config** below.
 - News becomes **global**: every Claude Code session shows the same item, so
   stepping moves them all together.
 - Works in **iTerm2, Apple Terminal, WezTerm, kitty**. In any other app the


### PR DESCRIPTION
Adds a brief line in the Keyboard navigation section pointing to the existing navKeys config knob (documented under Power-user config). Docs only — no behavior or version change.

https://claude.ai/code/session_01UhkPdZhbLbErwwjWUcFygy