### PR TITLE
fix(hud): status line intermittently wrapping — title budget ignored prefix/suffix (v0.23.1)

### DIFF
--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claudenews",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "description": "DevFeed — HackerNews and GitHub Trending in your status line while Claude Code thinks",
   "author": {
     "name": "bhpark1013",

--- a/plugin/hud/claudenews-hud.mjs
+++ b/plugin/hud/claudenews-hud.mjs
@@ -384,13 +384,24 @@ if (existsSync(newsFilePath)) {
     const raw = JSON.parse(readFileSync(newsFilePath, "utf-8"));
     const age = (Date.now() - raw.timestamp) / 1000;
     if (age < NEWS_TTL_SEC) {
-      const title = truncateCols(raw.title || "", maxCols);
       const source = raw.source || "";
       const url = raw.url || "";
       const scoreStr = raw.score ? ` \x1b[33m▲${raw.score}\x1b[0m` : "";
       const commentsStr = raw.comments
         ? ` \x1b[90m💬${raw.comments}\x1b[0m`
         : "";
+      // Truncate the title to what actually remains of line 1 after the
+      // label/source prefix and the score/comments suffix. Truncating to the
+      // full maxCols let long titles push the row past the terminal width, so
+      // the status line wrapped an extra line on long items and snapped back
+      // on short ones.
+      const fixedCols = visibleCols(
+        `${FEED_LABEL} ${source} │ ${scoreStr}${commentsStr}`
+      );
+      const title = truncateCols(
+        raw.title || "",
+        Math.max(16, maxCols - fixedCols)
+      );
 
       // Title is always an OSC 8 hyperlink so a click / ⌘-click opens the
       // article. Terminals without OSC 8 support just render the plain title


### PR DESCRIPTION
## Problem
The news line (row 1) intermittently wrapped to an extra terminal line and snapped back as items rotated.

`truncateCols(raw.title, maxCols)` truncated the title against the FULL terminal budget, but row 1 also carries the `[claude-news#ver] source │ ` prefix (~34–38 cols) and the ` ▲score 💬comments` suffix (~11 cols). Any title longer than `maxCols − prefix − suffix` overflowed the terminal width → the terminal wrapped the row. Short titles fit → no wrap. Hence the on/off flicker.

Measured on a real 122-col pane: a long HN title rendered row 1 at **163 cols (43 over)**.

## Fix
Compute the visible width of prefix+suffix first and truncate the title to what actually remains:
```js
const fixedCols = visibleCols(`${FEED_LABEL} ${source} │ ${scoreStr}${commentsStr}`);
const title = truncateCols(raw.title || "", Math.max(16, maxCols - fixedCols));
```

## Verification
Rendered long English/Korean titles with score+comments at 80/120/200-col widths — every row now measures ≤ maxCols (width−2); previously row 1 hit 163 cols at 120.