### PR TITLE
fix(hud): per-render COLUMNS width, bypass shared cache — summary re-wrap flicker (v0.23.2)

### DIFF
--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claudenews",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "description": "DevFeed — HackerNews and GitHub Trending in your status line while Claude Code thinks",
   "author": {
     "name": "bhpark1013",

--- a/plugin/hud/claudenews-hud.mjs
+++ b/plugin/hud/claudenews-hud.mjs
@@ -113,14 +113,25 @@ if (existsSync(CONFIG_FILE)) {
   } catch {}
 }
 
-// Detect actual terminal column width. Claude Code doesn't pass terminal
-// dimensions to statusline commands, so we probe the surrounding
-// environment: cmux RPC → tmux display-message → stty via /dev/tty. Each
-// channel either works in its environment or fails fast.
+// Detect actual terminal column width. Claude Code v2.1.153+ exports the live
+// terminal size as COLUMNS/LINES before running the statusline command —
+// exact, free, per-render, and per-PANE. Use it directly and skip the probe
+// cache entirely: one session can be shown in panes of different widths at
+// once (e.g. a second attached view), and the per-session cache lets one
+// pane's probe clobber the other's, re-wrapping the summary to a different
+// line count every few renders (the status bar visibly flickered between N
+// and N+1 lines). Older clients don't set COLUMNS, so fall back to probing
+// the environment (cmux RPC → controlling tty → bg pty-host argv → tmux →
+// iTerm2 → stty), cached with a short TTL because probes are slow.
 if (!userOverrodeMaxCols) {
-  const detected = detectTerminalColsCached();
-  if (detected && detected > 20) {
-    maxCols = detected;
+  const envCols = parseInt(process.env.COLUMNS || "", 10);
+  if (Number.isFinite(envCols) && envCols > 20) {
+    maxCols = envCols;
+  } else {
+    const detected = detectTerminalColsCached();
+    if (detected && detected > 20) {
+      maxCols = detected;
+    }
   }
 }
 


### PR DESCRIPTION
## Problem
Even after #4, the status line kept toggling between two wrap layouts (summary at 2 lines ↔ 3 lines).

Instrumenting live renders showed the same session id being rendered twice per second with **two different terminal widths (COLUMNS=109 and 179)** — the session was shown in two panes of different widths at once. The width-probe cache is keyed per *session*, so each pane's probe clobbered the other's entry, and the wide pane intermittently rendered with the narrow pane's width:

```
{"k":"01a16d20…","env":"109","maxCols":107}
{"k":"01a16d20…","env":"179","maxCols":107}   ← wide pane, narrow width
{"k":"01a16d20…","env":"109","maxCols":177}   ← narrow pane, wide width
```

## Fix
Claude Code v2.1.153+ exports the live terminal size as `COLUMNS` before running the statusline command — exact, free, per-render, per-pane. Prefer it and **skip the probe cache entirely** (putting the env check inside `detectTerminalCols()` would not be enough — the cached wrapper would still serve the other pane's stale entry for up to the 5s TTL). Older clients without `COLUMNS` keep the existing probe+cache path.

## Verification
- `COLUMNS=120` with a deliberately poisoned cache entry (300): every row renders ≤ 118 cols.
- `COLUMNS` unset: falls back to the probe cache as before.