### PR TITLE
feat: server-registered custom feeds (shared registry) (v0.24.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,19 +152,23 @@ backend; your selection just tells it what to merge.
 
 A few optional knobs you can set by hand (the plugin manages the rest):
 
-- **`clientFeeds`** — add any RSS/Atom feed the backend can't reach, fetched
-  from your own machine instead. Reddit is the headline case: it 403s
-  datacenter IPs, but `www.reddit.com/r/<sub>/.rss` works from a normal
-  machine. Items flow through rotation / nav / translation / summary exactly
-  like built-in sources — there's no per-source code, just URLs.
+- **Your own feeds** — add any RSS/Atom feed with **`/claudenews:list add r/<sub>`**
+  or `/claudenews:list add <url>` (or just ask Claude — *"add r/rust"*). The
+  feed is registered in the backend's **shared registry**: it gets a public
+  source id (`cf-…`), the backend fetches it once per cache window for every
+  install (so rate-limited hosts like Reddit see one request instead of one per
+  user), and anyone can enable it from `/claudenews:list`. Items flow through
+  rotation / nav / translation / summary exactly like built-in sources — the
+  feed's own body text is used for the summary when the page blocks scraping.
+  `/claudenews:list rmfeed <id | r/sub>` turns it off for you (the registry is
+  shared, so nothing is deleted for others).
 
-  Easiest way to add one: **`/claudenews:list add r/<sub>`** (or just ask
-  Claude — *"add r/rust"*); `/claudenews:list rmfeed r/<sub>` removes it. The
-  command writes this for you, and you can also edit it by hand:
+  Existing `clientFeeds` entries are migrated to the registry automatically.
+  Only a feed the backend genuinely cannot fetch stays in **`clientFeeds`**
+  (fetched from your own machine); you can still add one by hand:
 
   ```json
   "clientFeeds": [
-    {"name": "👽 r/ClaudeAI", "url": "https://www.reddit.com/r/ClaudeAI/.rss"},
     {"name": "🐘 #rust", "url": "https://mastodon.social/tags/rust.rss", "lang": "en"}
   ]
   ```

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claudenews",
-  "version": "0.23.3",
+  "version": "0.24.0",
   "description": "DevFeed — HackerNews and GitHub Trending in your status line while Claude Code thinks",
   "author": {
     "name": "bhpark1013",

--- a/plugin/commands/list.md
+++ b/plugin/commands/list.md
@@ -7,11 +7,14 @@ allowed-tools: Bash(bash:*)
 Show every news source with its on/off state, or toggle sources by id.
 
 - `/claudenews:list` — print the full inline menu (every source id +
-  flag + on/off) plus your own client feeds. No window.
-- `/claudenews:list cnn bbc hn` — toggle one or more sources by id
+  flag + on/off) plus community feeds registered by users. No window.
+- `/claudenews:list cnn bbc hn cf-1a2b3c4d5e` — toggle one or more sources by id
 - `/claudenews:list add r/<sub>` — add your own feed: a subreddit, or any
-  RSS/Atom URL the backend can't reach (fetched on your machine)
-- `/claudenews:list rmfeed r/<sub>` — remove one of your own feeds
+  RSS/Atom URL. It is registered in the backend's shared registry (fetched
+  server-side once for everyone) and turned on for you; only a URL the
+  backend cannot fetch falls back to a client feed fetched on your machine.
+- `/claudenews:list rmfeed <id | r/<sub> | url-fragment>` — turn one of your
+  feeds off (community feeds are shared, so they are disabled, not deleted)
 
 The inline list **is** the menu — it shows exactly what you can pick
 and the exact ids to type. Run it with no args first to see options,
@@ -29,4 +32,4 @@ their request to a `list.sh` call and run it:
 - "add r/rust" / "follow the rust subreddit" → `list.sh add r/rust`
   (Reddit shorthand is `r/<sub>`).
 - "add this feed `<url>`" / any RSS/Atom link → `list.sh add <url>`.
-- "remove r/rust" / "drop that feed" → `list.sh rmfeed r/rust`.
+- "remove r/rust" / "drop that feed" → `list.sh rmfeed r/rust` (or by `cf-…` id).

--- a/plugin/commands/list.sh
+++ b/plugin/commands/list.sh
@@ -34,7 +34,8 @@ except Exception: catalog = []
 if not catalog:
     try:
         with urllib.request.urlopen(api + "/api/sources", timeout=4) as r:
-            catalog = (json.loads(r.read()) or {}).get("sources") or []
+            d = json.loads(r.read()) or {}
+            catalog = (d.get("sources") or []) + (d.get("customFeeds") or [])
         if catalog: json.dump(catalog, open(cache_path, "w"))
     except Exception: catalog = []
 if not catalog:
@@ -63,10 +64,23 @@ if not isinstance(sel, dict) or not sel:
         if not on and lang in (s.get("defaultOnLangs") or []): on = True
         sel[s["id"]] = on
 print("  News sources  —  toggle with: /claudenews:list <id> [<id>...]")
-for s in catalog:
+builtin = [s for s in catalog if not s.get("custom")]
+custom = [s for s in catalog if s.get("custom")]
+for s in builtin:
     i = s["id"]
     mark = "[x]" if sel.get(i) else "[ ]"
     print(f"   {mark} {i:10s} {s.get('name','')}")
+if custom:
+    on = [s for s in custom if sel.get(s["id"])]
+    off = [s for s in custom if not sel.get(s["id"])]
+    print("  Community feeds (registered by users, served by the backend):")
+    for s in on:
+        print(f"   [x] {s['id']:14s} {s.get('name','')}  {s.get('url','')}")
+    MAX_OFF = 12
+    for s in off[:MAX_OFF]:
+        print(f"   [ ] {s['id']:14s} {s.get('name','')}")
+    if len(off) > MAX_OFF:
+        print(f"       … {len(off) - MAX_OFF} more (see {api}/api/feeds)")
 print(f"  Config: {cfg_path}")
 PY
 }
@@ -90,7 +104,8 @@ except Exception: catalog = []
 if not catalog:
     try:
         with urllib.request.urlopen(api + "/api/sources", timeout=4) as r:
-            catalog = (json.loads(r.read()) or {}).get("sources") or []
+            d = json.loads(r.read()) or {}
+            catalog = (d.get("sources") or []) + (d.get("customFeeds") or [])
         if catalog: json.dump(catalog, open(cache_path, "w"))
     except Exception: catalog = []
 if not catalog:
@@ -140,19 +155,23 @@ if known:
 PY
 }
 
-# A client feed is any RSS/Atom URL fetched on THIS machine (for feeds the
-# backend can't reach, e.g. Reddit). Stored in config.json under clientFeeds.
+# Add your own feed: registered in the backend's shared registry (so it is
+# fetched server-side once for everyone and gets a public source id), then
+# enabled for this machine. Only if the backend cannot fetch the URL does it
+# fall back to a client feed (config.json clientFeeds, fetched locally).
 add_feed() {
-  python3 - "$CONFIG_FILE" "$@" <<'PY'
-import json, sys
-cfg_path = sys.argv[1]
-arg = (sys.argv[2] if len(sys.argv) > 2 else "").strip()
-name_override = " ".join(sys.argv[3:]).strip()
+  python3 - "$CONFIG_FILE" "$SOURCES_CACHE" "$@" <<'PY'
+import json, sys, os, urllib.request, urllib.error
+cfg_path, cache_path = sys.argv[1], sys.argv[2]
+arg = (sys.argv[3] if len(sys.argv) > 3 else "").strip()
+name_override = " ".join(sys.argv[4:]).strip()
+DEFAULT_API = "https://web-olive-three-47.vercel.app"
 try:
     cfg = json.load(open(cfg_path))
     if not isinstance(cfg, dict): cfg = {}
 except Exception:
     cfg = {}
+api = cfg.get("apiUrl", DEFAULT_API)
 low = arg.lower()
 url = name = None
 if low.startswith("r/") or low.startswith("/r/"):
@@ -167,44 +186,104 @@ if not url:
     print("  Usage: /claudenews:list add r/<subreddit>   (or a full RSS/Atom URL)")
     print("  e.g.   /claudenews:list add r/rust")
     sys.exit(0)
+
+def save(c):
+    with open(cfg_path, "w") as f:
+        json.dump(c, f, indent=2, ensure_ascii=False); f.write("\n")
+
+feed, err, unreachable = None, None, False
+try:
+    body = json.dumps({"url": url, "name": name}).encode()
+    req = urllib.request.Request(api + "/api/feeds", data=body, method="POST",
+                                 headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=20) as r:
+        d = json.loads(r.read()) or {}
+    feed = d.get("feed") if d.get("ok") else None
+    err = d.get("error")
+except urllib.error.HTTPError as e:
+    try: d = json.loads(e.read()) or {}
+    except Exception: d = {}
+    err = d.get("error") or ("http %s" % e.code)
+    unreachable = bool(d.get("unreachable"))
+except Exception as e:
+    err = "backend unreachable (%s)" % e
+
+if feed:
+    sel = cfg.get("sources") if isinstance(cfg.get("sources"), dict) else {}
+    sel[feed["id"]] = True
+    cfg["sources"] = sel
+    cfg["sourcesConfigured"] = True
+    # Drop a legacy client-side copy of the same feed, if any.
+    cf = [f for f in (cfg.get("clientFeeds") or []) if not (isinstance(f, dict) and f.get("url") == url)]
+    if cf: cfg["clientFeeds"] = cf
+    else: cfg.pop("clientFeeds", None)
+    save(cfg)
+    try: os.unlink(cache_path)   # refetch the catalog so the new id shows up
+    except Exception: pass
+    print("  %s your feed on the backend: %s" % ("registered" if d.get("created") else "enabled", feed.get("name")))
+    print("    id %s   %s" % (feed["id"], feed.get("url")))
+    print("  toggle later with: /claudenews:list %s" % feed["id"])
+    sys.exit(0)
+
+if not unreachable and not str(err).startswith("backend unreachable"):
+    print("  could not register feed: %s" % err)
+    sys.exit(0)
+
+# Backend can't fetch it (or is down): keep the old client-fetched path.
 feeds = cfg.get("clientFeeds")
 if not isinstance(feeds, list): feeds = []
 if any(isinstance(f, dict) and f.get("url") == url for f in feeds):
-    print("  already added: %s" % url); sys.exit(0)
+    print("  already added (client feed): %s" % url); sys.exit(0)
 feeds.append({"name": name, "url": url})
 cfg["clientFeeds"] = feeds
-with open(cfg_path, "w") as f:
-    json.dump(cfg, f, indent=2, ensure_ascii=False); f.write("\n")
-print("  added your feed: %s" % name)
+save(cfg)
+print("  backend could not fetch it (%s) — added as a client feed fetched on this machine: %s" % (err, name))
 print("    %s" % url)
 PY
 }
 
 remove_feed() {
-  python3 - "$CONFIG_FILE" "$@" <<'PY'
-import json, sys
-cfg_path = sys.argv[1]
-arg = (sys.argv[2] if len(sys.argv) > 2 else "").strip().lower()
+  python3 - "$CONFIG_FILE" "$SOURCES_CACHE" "$@" <<'PY'
+import json, sys, os
+cfg_path, cache_path = sys.argv[1], sys.argv[2]
+arg = (sys.argv[3] if len(sys.argv) > 3 else "").strip().lower()
 try:
     cfg = json.load(open(cfg_path))
+    if not isinstance(cfg, dict): cfg = {}
 except Exception:
     cfg = {}
-feeds = (cfg or {}).get("clientFeeds")
-if not isinstance(feeds, list) or not feeds:
-    print("  you have no client feeds"); sys.exit(0)
 if arg.startswith("r/") or arg.startswith("/r/"):
     arg = "reddit.com/r/%s/" % arg.split("r/", 1)[1].strip("/")
 if not arg:
-    print("  Usage: /claudenews:list rmfeed <r/sub | url-fragment | name>"); sys.exit(0)
-kept = [f for f in feeds if not (isinstance(f, dict) and
-        (arg in (f.get("url", "").lower()) or arg in (f.get("name", "").lower())))]
-n = len(feeds) - len(kept)
-if not n:
+    print("  Usage: /claudenews:list rmfeed <r/sub | cf-id | url-fragment | name>"); sys.exit(0)
+try: catalog = json.load(open(cache_path)) if os.path.exists(cache_path) else []
+except Exception: catalog = []
+sel = cfg.get("sources") if isinstance(cfg.get("sources"), dict) else {}
+changed = 0
+# Community feeds are shared — "removing" one just turns it off for you.
+for s in catalog:
+    if not s.get("custom") or not sel.get(s["id"]): continue
+    hay = " ".join([s["id"], s.get("url", ""), s.get("name", "")]).lower()
+    if arg in hay:
+        sel[s["id"]] = False; changed += 1
+        print("  turned off: %s (%s)" % (s.get("name", ""), s["id"]))
+if changed:
+    cfg["sources"] = sel
+# Legacy client feeds are private to this machine — delete outright.
+feeds = cfg.get("clientFeeds")
+if isinstance(feeds, list) and feeds:
+    kept = [f for f in feeds if not (isinstance(f, dict) and
+            (arg in (f.get("url", "").lower()) or arg in (f.get("name", "").lower())))]
+    n = len(feeds) - len(kept)
+    if n:
+        changed += n
+        if kept: cfg["clientFeeds"] = kept
+        else: cfg.pop("clientFeeds", None)
+        print("  removed %d client feed(s) matching '%s'" % (n, arg))
+if not changed:
     print("  no feed matched: %s" % arg); sys.exit(0)
-cfg["clientFeeds"] = kept
 with open(cfg_path, "w") as f:
     json.dump(cfg, f, indent=2, ensure_ascii=False); f.write("\n")
-print("  removed %d feed(s) matching '%s'" % (n, arg))
 PY
 }
 
@@ -217,11 +296,12 @@ except Exception:
     cfg = {}
 feeds = (cfg or {}).get("clientFeeds") or []
 if isinstance(feeds, list) and feeds:
-    print("  Your own feeds (fetched on this machine):")
+    print("  Client feeds (backend can't reach these; fetched on this machine):")
     for f in feeds:
         if isinstance(f, dict):
             print("     - %s  %s" % (f.get("name", ""), f.get("url", "")))
 print("  Add your own:  /claudenews:list add r/<subreddit>   (or any RSS URL)")
+print("  Turn one off:  /claudenews:list rmfeed <id | r/sub | url-fragment>")
 PY
 }
 

--- a/plugin/hooks/show-news.py
+++ b/plugin/hooks/show-news.py
@@ -277,7 +277,10 @@ def fetch_sources_catalog(api_url):
     try:
         req = urllib.request.Request(f"{api_url}/api/sources", method="GET")
         with urllib.request.urlopen(req, timeout=3) as resp:
-            catalog = (json.loads(resp.read()) or {}).get("sources") or []
+            data = json.loads(resp.read()) or {}
+            # Built-in catalog + the shared registry of user-registered feeds
+            # (custom: True). Both are toggled by id the same way.
+            catalog = (data.get("sources") or []) + (data.get("customFeeds") or [])
         if catalog:
             try:
                 with open(SOURCES_CACHE, "w", encoding="utf-8") as f:
@@ -788,6 +791,109 @@ def refresh_clientfeeds_cache(feeds):
     return items
 
 
+FEEDS_MIGRATE_MARKER = os.path.join(CONFIG_DIR, ".feeds-migrate.ts")
+FEEDS_MIGRATE_RETRY_SEC = 6 * 3600
+
+
+def register_feed(api_url, url, name="", lang=""):
+    """Register a feed in the server's shared registry. Returns (feed, error)
+    where feed = {id,name,url,lang} on success; error carries 'unreachable'
+    when the backend cannot fetch that URL (keep it as a client feed)."""
+    body = json.dumps({"url": url, "name": name, "lang": lang}).encode()
+    req = urllib.request.Request(
+        f"{api_url}/api/feeds", data=body, method="POST",
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            data = json.loads(resp.read()) or {}
+        if data.get("ok") and data.get("feed"):
+            return data["feed"], None
+        return None, data.get("error") or "register failed"
+    except urllib.error.HTTPError as e:
+        try:
+            data = json.loads(e.read()) or {}
+        except Exception:
+            data = {}
+        err = data.get("error") or f"http {e.code}"
+        if data.get("unreachable"):
+            err = "unreachable"
+        return None, err
+    except Exception as e:
+        return None, f"network: {e}"
+
+
+def migrate_client_feeds(api_url):
+    """One-shot (retried at most every FEEDS_MIGRATE_RETRY_SEC): move legacy
+    config['clientFeeds'] into the server registry and enable the resulting
+    source ids. Feeds the backend can't reach stay as client feeds (fetched
+    locally), everything else is dropped from clientFeeds."""
+    cfg = load_config() or {}
+    feeds = cfg.get("clientFeeds")
+    if not isinstance(feeds, list) or not feeds:
+        return
+    try:
+        with open(FEEDS_MIGRATE_MARKER, "w") as f:
+            f.write(str(int(time.time())))
+    except Exception:
+        pass
+    keep, sel = [], cfg.get("sources") if isinstance(cfg.get("sources"), dict) else {}
+    migrated = 0
+    for f in feeds:
+        if not isinstance(f, dict) or not f.get("url"):
+            continue
+        feed, err = register_feed(api_url, f["url"], f.get("name") or "", f.get("lang") or "")
+        if feed:
+            sel[feed["id"]] = True
+            migrated += 1
+            log(f"feed migrated to server: {feed['name']} -> {feed['id']}")
+        else:
+            keep.append(f)
+            log(f"feed kept client-side ({err}): {f.get('name') or f['url']}")
+            if str(err).startswith("network"):
+                # Backend down: keep the rest too and try again later.
+                keep.extend(x for x in feeds if x is not f and x not in keep)
+                break
+    if not migrated:
+        return
+    cfg = load_config() or {}
+    cfg["sources"] = {**(cfg.get("sources") or {}), **sel}
+    cfg["sourcesConfigured"] = True
+    if keep:
+        cfg["clientFeeds"] = keep
+    else:
+        cfg.pop("clientFeeds", None)
+    try:
+        atomic_write_json(CONFIG_FILE, cfg)
+    except Exception as e:
+        log(f"feed migration: config write failed: {e}")
+        return
+    try:
+        os.unlink(SOURCES_CACHE)   # pick up the new ids on the next catalog fetch
+    except Exception:
+        pass
+    log(f"feed migration done: {migrated} moved, {len(keep)} kept client-side")
+
+
+def _spawn_feeds_migration():
+    try:
+        st = os.stat(FEEDS_MIGRATE_MARKER)
+        if time.time() - st.st_mtime < FEEDS_MIGRATE_RETRY_SEC:
+            return
+    except Exception:
+        pass
+    try:
+        subprocess.Popen(
+            [sys.executable, os.path.abspath(__file__), "--migrate-feeds"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            stdin=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+    except Exception as e:
+        log(f"feed migration spawn failed: {e}")
+
+
 def _spawn_clientfeeds_refresh():
     """Refresh client feeds in a DETACHED process so the 5s news hook never
     blocks on their network fetch."""
@@ -821,7 +927,8 @@ def merge_client_feeds(items, config):
 def save_news_list(items):
     """Persist the ordered candidate list so --nav can step through it."""
     slim = [
-        {k: it.get(k) for k in ("title", "url", "source", "score", "comments", "lang")}
+        {k: it.get(k) for k in ("title", "url", "source", "score", "comments",
+                                "lang", "feed_text", "custom")}
         for it in items
         if isinstance(it, dict) and it.get("url")
     ]
@@ -905,7 +1012,8 @@ def do_nav(direction):
     original_title = item.get("title", "") or ""
     summary_lang = target_lang if translate_enabled else "en"
     if url and not cached_summary(url, summary_lang):
-        launch_summarizer(url, original_title, summary_lang)
+        launch_summarizer(url, original_title, summary_lang,
+                          raw_text=item.get("feed_text") or "")
     if (translate_enabled and item.get("lang") != target_lang
             and not cached_translation(original_title, target_lang)):
         launch_translator(original_title, target_lang)
@@ -925,7 +1033,8 @@ def do_nav(direction):
                 and n_title and not cached_translation(n_title, target_lang)):
             launch_translator(n_title, target_lang)
         if off <= 2 and n_url and not cached_summary(n_url, summary_lang):
-            launch_summarizer(n_url, n_title, summary_lang)
+            launch_summarizer(n_url, n_title, summary_lang,
+                              raw_text=nxt.get("feed_text") or "")
     log(f"nav {direction} -> [{index}/{len(items)}] {record.get('title', '')[:40]}")
 
 
@@ -981,6 +1090,12 @@ def main():
         return
 
     save_timestamp(last_open_file)
+
+    # Legacy client-fetched feeds move into the server's shared registry
+    # (detached; the hook never waits on it). Whatever the backend can't
+    # reach stays client-fetched via merge_client_feeds below.
+    if (config or {}).get("clientFeeds"):
+        _spawn_feeds_migration()
 
     catalog = fetch_sources_catalog(api_url)
     selected = resolve_sources(config, catalog)
@@ -1048,13 +1163,14 @@ def main():
         return [it for it in lst if it.get("url") not in recent]
 
     # Eligible for rotation = has a cached summary (instant full render) OR is a
-    # client-feed item. Client feeds (e.g. Reddit) never get a scrapable summary,
-    # but should still rotate into the status line (title-only) instead of being
-    # reachable by nav only.
+    # feed item (server-registered custom feed or legacy client feed). Those
+    # sources (e.g. Reddit) never get a scrapable summary, but should still
+    # rotate into the status line (title-only) instead of being nav-only.
     cached_candidates = [
         it for it in items
         if isinstance(it, dict) and it.get("url")
-        and (cached_summary(it["url"], summary_lang) or it.get("clientfeed"))
+        and (cached_summary(it["url"], summary_lang)
+             or it.get("clientfeed") or it.get("custom"))
     ]
     # Prefer cached-summary items not shown recently; degrade gracefully so we
     # still end up with something when everything's been seen.
@@ -1146,7 +1262,8 @@ def main():
 
     # Launch summarizer if URL present and no cached summary yet
     if url and not summary:
-        launch_summarizer(url, original_title, summary_lang)
+        launch_summarizer(url, original_title, summary_lang,
+                          raw_text=pick.get("feed_text") or "")
         log(f"launched summarizer ({summary_lang})")
 
     # Pre-warm cache so rotation has enough cached-summary items to draw from
@@ -1176,7 +1293,8 @@ def main():
             continue
         if cached_summary(item_url, summary_lang):
             continue
-        launch_summarizer(item_url, item_title, summary_lang)
+        launch_summarizer(item_url, item_title, summary_lang,
+                          raw_text=item.get("feed_text") or "")
         prewarmed += 1
     if prewarmed:
         log(
@@ -1201,6 +1319,13 @@ if __name__ == "__main__":
             refresh_clientfeeds_cache((_cfg or {}).get("clientFeeds") or [])
         except Exception as e:
             log(f"client feeds refresh error: {e}")
+        sys.exit(0)
+    if len(sys.argv) >= 2 and sys.argv[1] == "--migrate-feeds":
+        try:
+            _cfg = load_config() or {}
+            migrate_client_feeds(_cfg.get("apiUrl", DEFAULT_API))
+        except Exception as e:
+            log(f"feed migration error: {e}")
         sys.exit(0)
     if len(sys.argv) >= 2 and sys.argv[1] == "--nav":
         _direction = sys.argv[2] if len(sys.argv) >= 3 else "next"

--- a/web/src/app/api/feeds/route.ts
+++ b/web/src/app/api/feeds/route.ts
@@ -1,0 +1,128 @@
+import { NextRequest } from "next/server";
+import {
+  CustomFeed,
+  MAX_FEEDS,
+  feedIdFor,
+  loadCustomFeeds,
+  normalizeFeedUrl,
+  sanitizeLang,
+  sanitizeName,
+  saveCustomFeeds,
+} from "@/lib/feeds";
+import { kvConfigured } from "@/lib/kv";
+import { BROWSER_UA, CUSTOM_FEED_OPTS, parseFeedXml } from "@/lib/rss";
+
+const ADMIN_TOKEN = process.env.ADMIN_TOKEN;
+
+function publicView(f: CustomFeed) {
+  return { id: f.id, name: f.name, url: f.url, lang: f.lang, addedAt: f.addedAt };
+}
+
+// GET → the shared registry (every feed anyone registered).
+export async function GET() {
+  const feeds = await loadCustomFeeds();
+  return Response.json(
+    { feeds: feeds.map(publicView) },
+    { headers: { "Cache-Control": "public, max-age=60" } }
+  );
+}
+
+// POST { url, name?, lang? } → register (or return the existing entry for
+// the same URL). The server fetches the feed once here to prove it is
+// reachable from the backend and parses as RSS/Atom; feeds that fail get
+// 422 so the client can keep fetching them locally instead.
+export async function POST(request: NextRequest) {
+  let body: { url?: unknown; name?: unknown; lang?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ ok: false, error: "invalid json" }, { status: 400 });
+  }
+  if (!kvConfigured) {
+    return Response.json(
+      { ok: false, error: "registry unavailable" },
+      { status: 503 }
+    );
+  }
+  const url = normalizeFeedUrl(String(body.url ?? ""));
+  if (!url) {
+    return Response.json(
+      { ok: false, error: "invalid url (public http/https feed required)" },
+      { status: 400 }
+    );
+  }
+  const id = feedIdFor(url);
+  const feeds = await loadCustomFeeds(true);
+  const existing = feeds.find((f) => f.id === id);
+  if (existing) {
+    return Response.json({ ok: true, created: false, feed: publicView(existing) });
+  }
+  if (feeds.length >= MAX_FEEDS) {
+    return Response.json(
+      { ok: false, error: "registry full" },
+      { status: 507 }
+    );
+  }
+  const name = sanitizeName(body.name, url);
+  // Prove the backend can fetch + parse it before anyone can enable it.
+  let entries = 0;
+  try {
+    const res = await fetch(url, {
+      headers: { "User-Agent": BROWSER_UA, Accept: "*/*" },
+      cache: "no-store",
+      signal: AbortSignal.timeout(8000),
+    });
+    if (!res.ok) {
+      return Response.json(
+        { ok: false, error: `feed fetch failed (${res.status})`, unreachable: true },
+        { status: 422 }
+      );
+    }
+    const xml = (await res.text()).slice(0, 1_000_000);
+    entries = parseFeedXml(xml, name, { ...CUSTOM_FEED_OPTS, maxAgeDays: 0 }).length;
+  } catch {
+    return Response.json(
+      { ok: false, error: "feed fetch failed", unreachable: true },
+      { status: 422 }
+    );
+  }
+  if (!entries) {
+    return Response.json(
+      { ok: false, error: "no RSS/Atom entries found at that url" },
+      { status: 422 }
+    );
+  }
+  const feed: CustomFeed = {
+    id,
+    name,
+    url,
+    lang: sanitizeLang(body.lang),
+    addedAt: Date.now(),
+  };
+  const saved = await saveCustomFeeds([...feeds, feed]);
+  if (!saved) {
+    return Response.json({ ok: false, error: "save failed" }, { status: 500 });
+  }
+  return Response.json({ ok: true, created: true, feed: publicView(feed) });
+}
+
+// DELETE { admin, id } → maintainer-only removal (spam / dead feeds).
+export async function DELETE(request: NextRequest) {
+  let body: { admin?: unknown; id?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ ok: false, error: "invalid json" }, { status: 400 });
+  }
+  if (!ADMIN_TOKEN || String(body.admin ?? "") !== ADMIN_TOKEN) {
+    return Response.json({ ok: false, error: "unauthorized" }, { status: 401 });
+  }
+  const id = String(body.id ?? "");
+  const feeds = await loadCustomFeeds(true);
+  const kept = feeds.filter((f) => f.id !== id);
+  if (kept.length === feeds.length) {
+    return Response.json({ ok: false, error: "not found" }, { status: 404 });
+  }
+  await saveCustomFeeds(kept);
+  return Response.json({ ok: true, removed: id });
+}

--- a/web/src/app/api/feeds/route.ts
+++ b/web/src/app/api/feeds/route.ts
@@ -10,7 +10,7 @@ import {
   saveCustomFeeds,
 } from "@/lib/feeds";
 import { kvConfigured } from "@/lib/kv";
-import { BROWSER_UA, CUSTOM_FEED_OPTS, parseFeedXml } from "@/lib/rss";
+import { CUSTOM_FEED_OPTS, fetchFeed } from "@/lib/rss";
 
 const ADMIN_TOKEN = process.env.ADMIN_TOKEN;
 
@@ -38,17 +38,17 @@ export async function POST(request: NextRequest) {
   } catch {
     return Response.json({ ok: false, error: "invalid json" }, { status: 400 });
   }
-  if (!kvConfigured) {
-    return Response.json(
-      { ok: false, error: "registry unavailable" },
-      { status: 503 }
-    );
-  }
   const url = normalizeFeedUrl(String(body.url ?? ""));
   if (!url) {
     return Response.json(
       { ok: false, error: "invalid url (public http/https feed required)" },
       { status: 400 }
+    );
+  }
+  if (!kvConfigured) {
+    return Response.json(
+      { ok: false, error: "registry unavailable" },
+      { status: 503 }
     );
   }
   const id = feedIdFor(url);
@@ -64,29 +64,19 @@ export async function POST(request: NextRequest) {
     );
   }
   const name = sanitizeName(body.name, url);
-  // Prove the backend can fetch + parse it before anyone can enable it.
-  let entries = 0;
-  try {
-    const res = await fetch(url, {
-      headers: { "User-Agent": BROWSER_UA, Accept: "*/*" },
-      cache: "no-store",
-      signal: AbortSignal.timeout(8000),
-    });
-    if (!res.ok) {
-      return Response.json(
-        { ok: false, error: `feed fetch failed (${res.status})`, unreachable: true },
-        { status: 422 }
-      );
-    }
-    const xml = (await res.text()).slice(0, 1_000_000);
-    entries = parseFeedXml(xml, name, { ...CUSTOM_FEED_OPTS, maxAgeDays: 0 }).length;
-  } catch {
+  // Prove the backend can fetch + parse it before anyone can enable it. Same
+  // fetch path (and cache) as /api/news, so this probe is the ONLY origin
+  // request for the next 10 minutes. Age gate off: an all-old-but-valid feed
+  // still registers.
+  const probe = await fetchFeed(url, name, { ...CUSTOM_FEED_OPTS, maxAgeDays: 0 });
+  if (!probe.ok) {
+    const why = probe.status ? `feed fetch failed (${probe.status})` : "feed fetch failed";
     return Response.json(
-      { ok: false, error: "feed fetch failed", unreachable: true },
+      { ok: false, error: why, unreachable: true },
       { status: 422 }
     );
   }
-  if (!entries) {
+  if (!probe.items.length) {
     return Response.json(
       { ok: false, error: "no RSS/Atom entries found at that url" },
       { status: 422 }

--- a/web/src/app/api/news/route.ts
+++ b/web/src/app/api/news/route.ts
@@ -1,17 +1,9 @@
 import { NextRequest } from "next/server";
 import { CATALOG_BY_ID } from "@/lib/sources";
+import { findCustomFeed, isCustomFeedId } from "@/lib/feeds";
+import type { NewsItem } from "@/lib/news-item";
+import { CUSTOM_FEED_OPTS, fetchRss } from "@/lib/rss";
 
-export interface NewsItem {
-  id: string;
-  title: string;
-  url: string;
-  source: string;
-  lang?: string;
-  score?: number;
-  comments?: number;
-  author?: string;
-  timestamp: number;
-}
 
 // Per-source in-memory cache (lives for the function's warm duration).
 // Keyed by source id so different ?sources= combinations share fetches.
@@ -89,75 +81,24 @@ async function fetchGitHubTrending(): Promise<NewsItem[]> {
   }
 }
 
-function decodeEntities(s: string): string {
-  return s
-    .replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, "$1")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;|&apos;/g, "'")
-    .replace(/&amp;/g, "&")
-    .replace(/<[^>]+>/g, "")
-    .trim();
-}
-
-// Minimal RSS 2.0 / Atom parser (regex, no deps). Only used for PUBLIC
-// catalog feeds (e.g. GeekNews), never user-private URLs.
-async function fetchRss(url: string, sourceName: string): Promise<NewsItem[]> {
-  try {
-    const res = await fetch(url, {
-      headers: { "User-Agent": "claudenews/1.0" },
-      next: { revalidate: 600 },
-    });
-    if (!res.ok) return [];
-    const xml = await res.text();
-    const blocks =
-      xml.indexOf("<item") !== -1
-        ? xml.split(/<item[\s>]/).slice(1)
-        : xml.split(/<entry[\s>]/).slice(1);
-    const pick = (b: string, tag: string) => {
-      const m = b.match(new RegExp(`<${tag}[^>]*>([\\s\\S]*?)</${tag}>`, "i"));
-      return m ? decodeEntities(m[1]) : "";
-    };
-    const out: NewsItem[] = [];
-    for (const b of blocks.slice(0, 30)) {
-      const title = pick(b, "title");
-      let link = pick(b, "link");
-      if (!link) {
-        const hm = b.match(/<link[^>]*href=["']([^"']+)["']/i); // Atom
-        link = hm ? hm[1] : "";
-      }
-      if (!title || !link) continue;
-      const ts =
-        Date.parse(pick(b, "pubDate") || pick(b, "updated") || "") || Date.now();
-      out.push({
-        id: `rss-${sourceName}-${link}`,
-        title,
-        url: link,
-        source: sourceName,
-        timestamp: ts,
-      });
-    }
-    return out;
-  } catch {
-    return [];
-  }
-}
-
 async function getSource(id: string): Promise<NewsItem[]> {
   const c = cache[id];
   if (c && Date.now() - c.at < CACHE_TTL_MS) return c.items;
   let items: NewsItem[] = [];
   if (id === "hn") items = await fetchHackerNews();
   else if (id === "github") items = await fetchGitHubTrending();
-  else {
+  else if (isCustomFeedId(id)) {
+    const feed = await findCustomFeed(id);
+    if (feed) items = await fetchRss(feed.url, feed.name, CUSTOM_FEED_OPTS);
+  } else {
     const def = CATALOG_BY_ID[id];
     if (def?.type === "rss" && def.url)
       items = await fetchRss(def.url, def.name);
   }
   // Tag each item with its source's content language so the plugin can skip
   // translating a source that's already in the user's target language.
-  const lang = CATALOG_BY_ID[id]?.lang ?? "en";
+  let lang = CATALOG_BY_ID[id]?.lang ?? "en";
+  if (isCustomFeedId(id)) lang = (await findCustomFeed(id))?.lang ?? "en";
   items = items.map((it) => ({ ...it, lang }));
   cache[id] = { items, at: Date.now() };
   return items;
@@ -180,7 +121,7 @@ export async function GET(request: NextRequest) {
   const requested = (request.nextUrl.searchParams.get("sources") || "")
     .split(",")
     .map((s) => s.trim())
-    .filter((s) => s && CATALOG_BY_ID[s]);
+    .filter((s) => s && (CATALOG_BY_ID[s] || isCustomFeedId(s)));
   // Default to the always-on builtin sources if none specified.
   const ids = requested.length ? requested : ["hn", "github"];
 

--- a/web/src/app/api/sources/route.ts
+++ b/web/src/app/api/sources/route.ts
@@ -1,8 +1,11 @@
 import { CATALOG } from "@/lib/sources";
+import { loadCustomFeeds } from "@/lib/feeds";
 
-// Static catalog the plugin fetches to render its source toggle list.
-// No request data is read; same response for everyone.
+// Source catalog the plugin fetches to render its toggle list: the static
+// built-in catalog plus the shared registry of user-registered feeds
+// (customFeeds). Same response for everyone.
 export async function GET() {
+  const custom = await loadCustomFeeds();
   return Response.json(
     {
       sources: CATALOG.map((s) => ({
@@ -13,7 +16,17 @@ export async function GET() {
         defaultOn: s.defaultOn,
         defaultOnLangs: s.defaultOnLangs ?? [],
       })),
+      customFeeds: custom.map((f) => ({
+        id: f.id,
+        name: f.name,
+        type: "rss",
+        lang: f.lang,
+        url: f.url,
+        custom: true,
+        defaultOn: false,
+        defaultOnLangs: [],
+      })),
     },
-    { headers: { "Cache-Control": "public, max-age=3600" } }
+    { headers: { "Cache-Control": "public, max-age=300" } }
   );
 }

--- a/web/src/lib/feeds.ts
+++ b/web/src/lib/feeds.ts
@@ -1,0 +1,125 @@
+// Shared registry of user-registered RSS/Atom feeds ("custom feeds").
+//
+// A feed registered by any user becomes a public source id (cf-<hash>) that
+// every client can enable via /claudenews:list, and /api/news fetches it
+// server-side with the same per-source cache as catalog feeds. One fetch per
+// feed per cache window serves every install — which is also what keeps
+// rate-limited hosts (Reddit: ~1 unauthenticated request / 30s / IP) happy.
+//
+// Stored in KV under "feeds:json" as a JSON array of CustomFeed. Without KV
+// the registry is empty and registration is refused (nothing to persist).
+import { createHash } from "crypto";
+import { kv, kvConfigured } from "./kv";
+
+export interface CustomFeed {
+  id: string;        // "cf-" + 10 hex chars of sha1(normalized url)
+  name: string;      // display name shown as the item's source
+  url: string;       // feed URL (http/https, public host)
+  lang: string;      // 2-letter content language, default "en"
+  addedAt: number;   // epoch ms
+}
+
+export const FEED_ID_PREFIX = "cf-";
+export const MAX_FEEDS = 300;
+export const MAX_NAME_LEN = 60;
+export const MAX_URL_LEN = 500;
+const KV_KEY = "feeds:json";
+const REGISTRY_TTL_MS = 60 * 1000;
+
+let memo: { feeds: CustomFeed[]; at: number } | null = null;
+
+export function normalizeFeedUrl(raw: string): string | null {
+  const s = String(raw ?? "").trim();
+  if (!s || s.length > MAX_URL_LEN) return null;
+  let u: URL;
+  try {
+    u = new URL(s);
+  } catch {
+    return null;
+  }
+  if (u.protocol !== "http:" && u.protocol !== "https:") return null;
+  if (u.username || u.password) return null;
+  const host = u.hostname.toLowerCase();
+  // Public hosts only — the server fetches this URL, so refuse anything that
+  // could reach internal networks (SSRF): localhost, literal IPs, .local.
+  if (
+    !host.includes(".") ||
+    host === "localhost" ||
+    host.endsWith(".local") ||
+    host.endsWith(".internal") ||
+    /^[\d.]+$/.test(host) ||
+    host.includes(":")
+  )
+    return null;
+  u.hostname = host;
+  u.hash = "";
+  return u.toString();
+}
+
+export function feedIdFor(normalizedUrl: string): string {
+  return (
+    FEED_ID_PREFIX +
+    createHash("sha1").update(normalizedUrl).digest("hex").slice(0, 10)
+  );
+}
+
+export function isCustomFeedId(id: string): boolean {
+  return id.startsWith(FEED_ID_PREFIX);
+}
+
+export function sanitizeName(raw: unknown, fallbackUrl: string): string {
+  const s = String(raw ?? "")
+    .replace(/[\r\n\t]+/g, " ")
+    .trim()
+    .slice(0, MAX_NAME_LEN);
+  if (s) return s;
+  try {
+    return new URL(fallbackUrl).hostname;
+  } catch {
+    return "feed";
+  }
+}
+
+export function sanitizeLang(raw: unknown): string {
+  const s = String(raw ?? "").trim().toLowerCase();
+  return /^[a-z]{2}$/.test(s) ? s : "en";
+}
+
+function isFeed(x: unknown): x is CustomFeed {
+  if (!x || typeof x !== "object") return false;
+  const f = x as Record<string, unknown>;
+  return (
+    typeof f.id === "string" &&
+    typeof f.url === "string" &&
+    typeof f.name === "string"
+  );
+}
+
+export async function loadCustomFeeds(force = false): Promise<CustomFeed[]> {
+  if (!force && memo && Date.now() - memo.at < REGISTRY_TTL_MS)
+    return memo.feeds;
+  let feeds: CustomFeed[] = [];
+  const stored = await kv<string>(["GET", KV_KEY]);
+  if (stored) {
+    try {
+      const parsed = JSON.parse(stored);
+      if (Array.isArray(parsed)) feeds = parsed.filter(isFeed);
+    } catch {
+      feeds = [];
+    }
+  }
+  memo = { feeds, at: Date.now() };
+  return feeds;
+}
+
+export async function saveCustomFeeds(feeds: CustomFeed[]): Promise<boolean> {
+  if (!kvConfigured) return false;
+  const ok = await kv<string>(["SET", KV_KEY, JSON.stringify(feeds)]);
+  memo = { feeds, at: Date.now() };
+  return ok !== null;
+}
+
+export async function findCustomFeed(id: string): Promise<CustomFeed | null> {
+  const feeds = await loadCustomFeeds();
+  return feeds.find((f) => f.id === id) ?? null;
+}

--- a/web/src/lib/kv.ts
+++ b/web/src/lib/kv.ts
@@ -1,0 +1,27 @@
+// Minimal Upstash/Vercel KV REST helper shared by routes that persist small
+// JSON blobs (guides, custom feed registry). Returns null when KV is not
+// configured or the call fails, so callers degrade to in-code defaults.
+const KV_URL =
+  process.env.KV_REST_API_URL || process.env.UPSTASH_REDIS_REST_URL;
+const KV_TOKEN =
+  process.env.KV_REST_API_TOKEN || process.env.UPSTASH_REDIS_REST_TOKEN;
+
+export const kvConfigured = Boolean(KV_URL && KV_TOKEN);
+
+export async function kv<T = string | null>(cmd: string[]): Promise<T | null> {
+  if (!KV_URL || !KV_TOKEN) return null;
+  try {
+    const res = await fetch(
+      `${KV_URL}/${cmd.map(encodeURIComponent).join("/")}`,
+      {
+        headers: { Authorization: `Bearer ${KV_TOKEN}` },
+        cache: "no-store",
+      }
+    );
+    if (!res.ok) return null;
+    const json = await res.json();
+    return (json.result ?? null) as T | null;
+  } catch {
+    return null;
+  }
+}

--- a/web/src/lib/news-item.ts
+++ b/web/src/lib/news-item.ts
@@ -1,0 +1,15 @@
+export interface NewsItem {
+  id: string;
+  title: string;
+  url: string;
+  source: string;
+  lang?: string;
+  score?: number;
+  comments?: number;
+  author?: string;
+  timestamp: number;
+  // Custom (user-registered) feeds only: feed-provided body for sources whose
+  // pages block scraping (Reddit etc.), so the plugin's summarizer has text.
+  feed_text?: string;
+  custom?: boolean;
+}

--- a/web/src/lib/rss.ts
+++ b/web/src/lib/rss.ts
@@ -87,11 +87,22 @@ export function parseFeedXml(
   return out;
 }
 
-export async function fetchRss(
+export interface FeedFetchResult {
+  ok: boolean;       // HTTP fetch succeeded (2xx)
+  status: number;    // HTTP status, 0 on network error/timeout
+  items: NewsItem[];
+}
+
+// One fetch path for catalog feeds, custom feeds AND the registration probe.
+// Uses Next's Data Cache (revalidate) so a feed fetched by /api/feeds at
+// registration is served from cache to the /api/news call that follows —
+// one origin request instead of two, which matters for hosts that
+// rate-limit per IP (Reddit: ~1 unauthenticated request / 30s).
+export async function fetchFeed(
   url: string,
   sourceName: string,
   opts: RssOptions = {}
-): Promise<NewsItem[]> {
+): Promise<FeedFetchResult> {
   try {
     const res = await fetch(url, {
       headers: {
@@ -101,12 +112,20 @@ export async function fetchRss(
       next: { revalidate: 600 },
       signal: AbortSignal.timeout(8000),
     });
-    if (!res.ok) return [];
+    if (!res.ok) return { ok: false, status: res.status, items: [] };
     const xml = (await res.text()).slice(0, 1_000_000);
-    return parseFeedXml(xml, sourceName, opts);
+    return { ok: true, status: res.status, items: parseFeedXml(xml, sourceName, opts) };
   } catch {
-    return [];
+    return { ok: false, status: 0, items: [] };
   }
+}
+
+export async function fetchRss(
+  url: string,
+  sourceName: string,
+  opts: RssOptions = {}
+): Promise<NewsItem[]> {
+  return (await fetchFeed(url, sourceName, opts)).items;
 }
 
 // User-registered feeds: browser UA (Reddit), small per-feed cap so one feed

--- a/web/src/lib/rss.ts
+++ b/web/src/lib/rss.ts
@@ -1,0 +1,122 @@
+// RSS 2.0 / Atom parsing + fetching shared by /api/news (catalog + custom
+// feeds) and /api/feeds (registration probe). Regex-based, no deps.
+import type { NewsItem } from "./news-item";
+
+function decodeEntities(s: string): string {
+  return s
+    .replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, "$1")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;|&apos;/g, "'")
+    .replace(/&amp;/g, "&")
+    .replace(/<[^>]+>/g, "")
+    .trim();
+}
+
+// Minimal RSS 2.0 / Atom parser (regex, no deps). Used for PUBLIC catalog
+// feeds (e.g. GeekNews) and for user-registered custom feeds (public URLs,
+// validated at registration).
+export interface RssOptions {
+  browserUa?: boolean;   // Reddit & co. 403/429 non-browser UAs
+  maxItems?: number;
+  maxAgeDays?: number;   // drop dated entries older than this (pinned posts)
+  withBody?: boolean;    // include feed_text (stripped body, capped)
+  custom?: boolean;
+}
+export const BROWSER_UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 " +
+  "(KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36";
+const FEED_BODY_MAX = 1500;
+
+export function parseFeedXml(
+  xml: string,
+  sourceName: string,
+  opts: RssOptions = {}
+): NewsItem[] {
+  const maxItems = opts.maxItems ?? 30;
+  const blocks =
+    xml.indexOf("<item") !== -1
+      ? xml.split(/<item[\s>]/).slice(1)
+      : xml.split(/<entry[\s>]/).slice(1);
+  const pick = (b: string, tag: string) => {
+    const m = b.match(new RegExp(`<${tag}[^>]*>([\\s\\S]*?)</${tag}>`, "i"));
+    return m ? decodeEntities(m[1]) : "";
+  };
+  const out: NewsItem[] = [];
+  const seen = new Set<string>();
+  for (const b of blocks) {
+    if (out.length >= maxItems) break;
+    const title = pick(b, "title");
+    let link = pick(b, "link");
+    if (!link) {
+      const hm = b.match(/<link[^>]*href=["']([^"']+)["']/i); // Atom
+      link = hm ? hm[1] : "";
+    }
+    if (!title || !link || seen.has(link)) continue;
+    const dateStr =
+      pick(b, "pubDate") || pick(b, "published") || pick(b, "updated") || "";
+    const parsed = Date.parse(dateStr);
+    const ts = parsed || Date.now();
+    if (
+      opts.maxAgeDays &&
+      parsed &&
+      Date.now() - parsed > opts.maxAgeDays * 864e5
+    )
+      continue;
+    seen.add(link);
+    const item: NewsItem = {
+      id: `rss-${sourceName}-${link}`,
+      title,
+      url: link,
+      source: sourceName,
+      timestamp: ts,
+    };
+    if (opts.withBody) {
+      const body =
+        pick(b, "content:encoded") ||
+        pick(b, "content") ||
+        pick(b, "description") ||
+        pick(b, "summary");
+      const text = body.replace(/\s+/g, " ").trim().slice(0, FEED_BODY_MAX);
+      if (text) item.feed_text = text;
+    }
+    if (opts.custom) item.custom = true;
+    out.push(item);
+  }
+  return out;
+}
+
+export async function fetchRss(
+  url: string,
+  sourceName: string,
+  opts: RssOptions = {}
+): Promise<NewsItem[]> {
+  try {
+    const res = await fetch(url, {
+      headers: {
+        "User-Agent": opts.browserUa ? BROWSER_UA : "claudenews/1.0",
+        Accept: "*/*",
+      },
+      next: { revalidate: 600 },
+      signal: AbortSignal.timeout(8000),
+    });
+    if (!res.ok) return [];
+    const xml = (await res.text()).slice(0, 1_000_000);
+    return parseFeedXml(xml, sourceName, opts);
+  } catch {
+    return [];
+  }
+}
+
+// User-registered feeds: browser UA (Reddit), small per-feed cap so one feed
+// can't flood the round-robin, 14-day age gate (hot-order feeds surface old
+// pinned posts), and the feed body for summarization.
+export const CUSTOM_FEED_OPTS: RssOptions = {
+  browserUa: true,
+  maxItems: 12,
+  maxAgeDays: 14,
+  withBody: true,
+  custom: true,
+};
+


### PR DESCRIPTION
Custom RSS/Atom feeds (subreddits etc.) move from per-client fetching into a backend **shared registry**.

**web**
- `POST/GET/DELETE /api/feeds` — KV-backed registry (`feeds:json`). Ids are `cf-<sha1(url)[:10]>`. Public hosts only (no localhost / literal IP / `.local`). The backend fetches + parses the feed once at registration; if it cannot, `422 {unreachable:true}` so the client keeps the feed local.
- `/api/news` resolves `cf-*` ids and fetches them with a browser UA, 12-item cap, 14-day age gate, and `feed_text` (feed body) for summarization. RSS parsing moved to `lib/rss.ts`.
- `/api/sources` returns `customFeeds` so any install can enable a feed anyone registered.

**plugin**
- Catalog = `sources + customFeeds`; `cf-*` items rotate title-only like client feeds; `feed_text` goes to the summarizer at every launch site; nav list keeps `feed_text`/`custom`.
- Legacy `config.clientFeeds` migrate to the registry via a detached `--migrate-feeds` pass (retry 6h). Unreachable-from-backend feeds stay client-fetched.
- `list.sh add` registers on the backend and enables the id; `rmfeed` turns a shared feed off; the list shows a "Community feeds" section.

Why: one server fetch per feed per cache window serves every install, which is also what keeps Reddit's ~1 req/30s/IP limit out of the picture (the v0.23.3 429 saga).

https://claude.ai/code/session_01MBfScqQ7PADHjq9UZt2GTH