### PR TITLE
fix(feeds): space same-host registrations, surface 429 from the probe (v0.24.1)

### DIFF
--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claudenews",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "DevFeed — HackerNews and GitHub Trending in your status line while Claude Code thinks",
   "author": {
     "name": "bhpark1013",

--- a/plugin/commands/list.sh
+++ b/plugin/commands/list.sh
@@ -205,6 +205,12 @@ except urllib.error.HTTPError as e:
     except Exception: d = {}
     err = d.get("error") or ("http %s" % e.code)
     unreachable = bool(d.get("unreachable"))
+    if d.get("status") == 429:
+        # The feed host rate-limited the backend (Reddit: ~1 request / 30s per
+        # IP). Not a reachability problem — just try again shortly.
+        print("  the feed host rate-limited the backend (429) — run this again in ~30s:")
+        print("    /claudenews:list add %s" % arg)
+        sys.exit(0)
 except Exception as e:
     err = "backend unreachable (%s)" % e
 

--- a/plugin/hooks/show-news.py
+++ b/plugin/hooks/show-news.py
@@ -817,7 +817,9 @@ def register_feed(api_url, url, name="", lang=""):
             data = {}
         err = data.get("error") or f"http {e.code}"
         if data.get("unreachable"):
-            err = "unreachable"
+            # Origin status travels along: 429 = the backend got rate-limited
+            # by the feed host (Reddit: ~1 req/30s/IP), i.e. retryable.
+            err = "rate-limited" if data.get("status") == 429 else "unreachable"
         return None, err
     except Exception as e:
         return None, f"network: {e}"
@@ -839,10 +841,22 @@ def migrate_client_feeds(api_url):
         pass
     keep, sel = [], cfg.get("sources") if isinstance(cfg.get("sources"), dict) else {}
     migrated = 0
+    last_hit = {}   # host -> monotonic time the backend last probed it
     for f in feeds:
         if not isinstance(f, dict) or not f.get("url"):
             continue
+        # The backend probes the URL at registration, so two feeds on the same
+        # rate-limited host (Reddit) must be spaced like client fetches are.
+        host = _feed_host(f["url"])
+        gap = CLIENTFEED_SAME_HOST_GAP_SEC - (time.monotonic() - last_hit.get(host, -1e9))
+        if gap > 0:
+            time.sleep(gap)
+        last_hit[host] = time.monotonic()
         feed, err = register_feed(api_url, f["url"], f.get("name") or "", f.get("lang") or "")
+        if err == "rate-limited":
+            time.sleep(CLIENTFEED_SAME_HOST_GAP_SEC)
+            last_hit[host] = time.monotonic()
+            feed, err = register_feed(api_url, f["url"], f.get("name") or "", f.get("lang") or "")
         if feed:
             sel[feed["id"]] = True
             migrated += 1

--- a/web/src/app/api/feeds/route.ts
+++ b/web/src/app/api/feeds/route.ts
@@ -72,7 +72,7 @@ export async function POST(request: NextRequest) {
   if (!probe.ok) {
     const why = probe.status ? `feed fetch failed (${probe.status})` : "feed fetch failed";
     return Response.json(
-      { ok: false, error: why, unreachable: true },
+      { ok: false, error: why, unreachable: true, status: probe.status },
       { status: 422 }
     );
   }


### PR DESCRIPTION
Follow-up to #7. The registration probe hits the feed host once, so migrating two subreddits back-to-back made Reddit 429 the second one (~1 req/30s/IP) and the feed was kept client-side for 6h.

- `/api/feeds` 422 responses now carry the origin `status`.
- `migrate_client_feeds` spaces same-host registrations by `CLIENTFEED_SAME_HOST_GAP_SEC` (35s) and retries once after a 429 (detached process).
- `list.sh add` on a 429 prints "retry in ~30s" instead of silently creating a client feed.

https://claude.ai/code/session_01MBfScqQ7PADHjq9UZt2GTH