### PR TITLE
chore: add MIT LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 bhpark1013
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Why

`plugin/.claude-plugin/plugin.json` has declared `"license": "MIT"` since the start, but the repository never shipped a `LICENSE` file.

Without one, the default legal state of published code is **all rights reserved** — so despite the repo being public:

- nobody can legally fork, contribute to, or redistribute it
- many organizations block installing dependencies that carry no license
- curated directories (awesome-lists, plugin hubs) generally reject unlicensed projects

Since the plugin manifest already promises MIT, this just makes the repository match that promise.

## What

Adds a standard MIT `LICENSE` at the repo root, `Copyright (c) 2026 bhpark1013`.

No code changes.

https://claude.ai/code/session_013ZS4io8TJKUivqTbBpTPdy