### PR TITLE
fix(hud): sanitize feed-derived text before ANSI/OSC 8 rendering

### DIFF
--- a/plugin/hud/claudenews-hud.mjs
+++ b/plugin/hud/claudenews-hud.mjs
@@ -389,17 +389,37 @@ if (!navEnabled) {
   }
 }
 
+// Every field below comes straight from a remote feed (RSS/HN/reddit/a
+// server-registered custom feed), so none of it can be trusted to be plain
+// text. Strip C0 controls, DEL, and C1 (\x1b included) BEFORE any width math
+// or escape-sequence construction: stripping after truncateCols/visibleCols
+// would compute the column budget against the unstripped string and drift
+// the layout. Only control bytes are removed — emoji, CJK, box-drawing, and
+// all other Unicode pass through untouched.
+function strip(s) {
+  return String(s).replace(/[\x00-\x1f\x7f-\x9f]/g, "");
+}
+
 let newsLine = "";
 if (existsSync(newsFilePath)) {
   try {
     const raw = JSON.parse(readFileSync(newsFilePath, "utf-8"));
     const age = (Date.now() - raw.timestamp) / 1000;
     if (age < NEWS_TTL_SEC) {
-      const source = raw.source || "";
-      const url = raw.url || "";
-      const scoreStr = raw.score ? ` \x1b[33m▲${raw.score}\x1b[0m` : "";
+      const source = strip(raw.source || "");
+      // Only ever hyperlink to http(s). A feed-supplied scheme like
+      // "javascript:" or a broken-out OSC 8 escape hidden in the url field
+      // must never reach the terminal as a clickable target — fall through
+      // to the plain (non-link) render instead of emitting a bad anchor.
+      const strippedUrl = strip(raw.url || "");
+      const url = /^https?:\/\//i.test(strippedUrl) ? strippedUrl : "";
+      // Preserve the original truthy check (score/comments of 0 stay hidden)
+      // on the raw value, but sanitize what actually gets interpolated.
+      const scoreStr = raw.score
+        ? ` \x1b[33m▲${strip(String(raw.score))}\x1b[0m`
+        : "";
       const commentsStr = raw.comments
-        ? ` \x1b[90m💬${raw.comments}\x1b[0m`
+        ? ` \x1b[90m💬${strip(String(raw.comments))}\x1b[0m`
         : "";
       // Truncate the title to what actually remains of line 1 after the
       // label/source prefix and the score/comments suffix. Truncating to the
@@ -410,13 +430,15 @@ if (existsSync(newsFilePath)) {
         `${FEED_LABEL} ${source} │ ${scoreStr}${commentsStr}`
       );
       const title = truncateCols(
-        raw.title || "",
+        strip(raw.title || ""),
         Math.max(16, maxCols - fixedCols)
       );
 
       // Title is always an OSC 8 hyperlink so a click / ⌘-click opens the
       // article. Terminals without OSC 8 support just render the plain title
-      // (the escape is invisible), so this is safe everywhere.
+      // (the escape is invisible), so this is safe everywhere. `url` above is
+      // already stripped and scheme-validated, so it cannot break out of the
+      // OSC 8 framing or retarget the link.
       const titleStyled = url
         ? `\x1b]8;;${url}\x07\x1b[37;4m${title}\x1b[0m\x1b]8;;\x07`
         : `\x1b[37m${title}\x1b[0m`;
@@ -455,7 +477,7 @@ if (existsSync(newsFilePath)) {
         }
       }
 
-      const summary = (raw.summary || "").trim();
+      const summary = strip(raw.summary || "").trim();
       if (summary) {
         // "       ↳ " prefix is 9 display cols; continuation lines indent
         // 9 spaces so wrapped text stays aligned under the first line.


### PR DESCRIPTION
## Problem

Every field the status line renders — `title`, `summary`, `source`, `url`, `score`, `comments` — comes straight from a remote feed (HN, GitHub Trending, reddit, or a server-registered custom feed), and none of it was stripped of control characters before being interpolated into ANSI / OSC 8 escape sequences. There is no control-character strip anywhere in the plugin today.

`hud/claudenews-hud.mjs` built the title like this:

```js
const url = raw.url || "";                          // no scheme validation
const title = truncateCols(raw.title || "", ...);   // width truncation only

const titleStyled = url
  ? `\x1b]8;;${url}\x07\x1b[37;4m${title}\x1b[0m\x1b]8;;\x07`
  : `\x1b[37m${title}\x1b[0m`;
```

A malicious or compromised feed can put `\x1b]8;;https://phishing\x07` inside a title, break out of the OSC 8 anchor and **retarget the link** — the reader clicks what looks like a news headline and goes somewhere else. A `javascript:` url was passed through as a link target verbatim. On terminals that support OSC 52 the same hole reaches the clipboard.

Server-registered feeds (v0.24) widen this: feeds registered by other people also render here.

## Verification

Crafted a feed item with `\x1b]8;;https://phishing.example\x07` embedded in the title and `url = javascript:alert(1)`, rendered through `cat -v`.

Before — the injected OSC 8 escapes the anchor and the `javascript:` url becomes the real link target:
```
^[]8;;javascript:alert(1)^G^[[37;4mClick^[]8;;https://phishing.example^GRETARGET^[]8;;^G here
```

After — the `\x1b` bytes are gone, so `]8;;…` is inert literal text, and the rejected url falls through to the plain non-link branch:
```
^[[37mClick]8;;https://phishing.exampleRETARGET]8;; here^[[0m
```

No regression for legitimate content: an item with Korean text, an emoji and box-drawing characters renders **byte-for-byte identically** before and after (`cmp` clean).

## Fix

- `strip()` removes only C0, DEL and C1 (`\x00-\x1f`, `\x7f-\x9f`). Emoji, CJK, box-drawing and all other Unicode pass through untouched.
- Applied **before** `truncateCols()` / `visibleCols()` — stripping afterwards would compute the column budget against the unstripped string and drift the layout.
- `url` must match `^https?://` to be used as an OSC 8 target; anything else renders as plain text rather than a broken or hostile anchor.
- `score` and `comments` were unsanitized interpolation sites too, and are covered.

`raw.guides` (`GUIDES_CACHE`) is written by the maintainer's own `show-news.py`, not by third-party feeds, so it is left out of scope here.

https://claude.ai/code/session_013ZS4io8TJKUivqTbBpTPdy