### PR TITLE
fix(hud): honour the per-session mute marker

### DIFF
--- a/plugin/hud/claudenews-hud.mjs
+++ b/plugin/hud/claudenews-hud.mjs
@@ -80,6 +80,26 @@ try {
   stdinData = readFileSync(0, "utf-8");
 } catch {}
 
+// Per-session mute. `/session-hud off` drops a marker file named after the
+// session id; this check runs before any other work so a muted session costs
+// nothing at refreshInterval 1. Living here rather than in the thin launcher
+// at ~/.claude/hud/ is deliberate: /claudenews:setup rewrites that launcher on
+// every update, which is what silently removed an earlier hand-patched version
+// of this check. Failing open (HUD visible) is the safe default.
+const MUTE_DIR = join(HOME, ".claudenews/disabled-sessions");
+try {
+  const sid = String((JSON.parse(stdinData) || {}).session_id || "")
+    .replace(/[^A-Za-z0-9_-]/g, "")
+    .slice(0, 64);
+  if (sid && existsSync(join(MUTE_DIR, sid))) {
+    // One blank line, not an empty string: Claude Code keeps the status-line
+    // row either way, and printing nothing at all makes some terminals reuse
+    // the previous frame.
+    process.stdout.write("\n");
+    process.exit(0);
+  }
+} catch {}
+
 let parentOutput = "";
 let maxCols = 120; // safe default — Claude Code's statusline doesn't pass width
 let userOverrodeMaxCols = false;


### PR DESCRIPTION
## Problem

The `session-hud` skill turns the status line off for a single session by dropping a marker file named after the session id. **Nothing has read that marker for a while, so the skill has been a silent no-op** — `off` created the file and the HUD kept rendering.

The check used to live in the thin launcher installed at `~/.claude/hud/claudenews-hud.mjs`. `/claudenews:setup` rewrites that file on every plugin update, so a claudenews update deleted it. The `.bak` the skill's documentation pointed at is gone for the same reason.

## Fix

Move the check into the HUD itself, where plugin updates carry it along instead of overwriting it.

- Runs immediately after the stdin read, before any other work — this matters at `refreshInterval: 1`, so a muted session costs nothing.
- Session id is sanitized exactly as the existing per-session cache does, so the skill and the HUD agree on the marker filename.
- Marker moved from `~/.claude/hud/disabled-sessions/` to `~/.claudenews/disabled-sessions/`, alongside the rest of the plugin's state, rather than living in a directory that gets rewritten.
- Any failure falls open and renders the HUD.

## Verification

| Scenario | Result |
|---|---|
| No marker | HUD renders normally |
| `session-hud off` | Marker created |
| Marker present | Output is 0 bytes (one blank line) |
| `session-hud on` | Marker removed |
| After removal | HUD renders normally |
| `session-hud status` | Reports state correctly |
| Unrelated session id | Unaffected |

The companion skill was updated separately: its documentation described `~/.Codex/settings.json`, a 2-second refresh and a `.bak` that does not exist, and claimed to work on Codex while the script targeted `~/.claude/hud/` and `CLAUDE_CODE_SESSION_ID`. Codex cannot host this HUD at all — its `status_line` accepts only fixed built-in items and has no entry that runs a user command.

https://claude.ai/code/session_013ZS4io8TJKUivqTbBpTPdy