### PR TITLE
chore: release v0.25.0

### DIFF
--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claudenews",
-  "version": "0.24.1",
+  "version": "0.25.0",
   "description": "DevFeed — HackerNews and GitHub Trending in your status line while Claude Code thinks",
   "author": {
     "name": "bhpark1013",


### PR DESCRIPTION
Version bump only — `0.24.1` → `0.25.0`. Minor, because this cycle adds a new render mode.

## What ships

**#10 — sanitize feed-derived text before ANSI/OSC 8 rendering**
Remote feed `title`, `summary`, `source`, `url`, `score` and `comments` were interpolated into ANSI/OSC 8 escapes with no control-character stripping. A hostile or compromised feed could break out of the OSC 8 anchor and retarget the link, and a `javascript:` url was passed through as a click target verbatim. Server-registered feeds widened the exposure.

**#11 — honour the per-session mute marker**
The `session-hud` skill had been a silent no-op: the marker check lived in the launcher at `~/.claude/hud/`, which `/claudenews:setup` rewrites on every update, so a plugin update deleted it. The check now lives in the HUD itself.

**#12 — `--segment` mode**
Renders a single embeddable line sized from the host's `terminal_width`, so claudenews can run as a [ccstatusline](https://github.com/sirmalloc/ccstatusline) Custom Command widget instead of requiring the whole `statusLine` slot.

## Upgrade note

Roughly half of active installs were still on a version behind before this cycle, so **#10 is worth calling out as a security fix in any release note** — it is the strongest reason for those users to run `/claudenews:update`.

https://claude.ai/code/session_013ZS4io8TJKUivqTbBpTPdy