### PR TITLE
fix(web): site still advertised the abandoned CodeEarn product

### DIFF
--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import Script from "next/script";
 import { LocaleProvider } from "@/lib/i18n";
+import { SITE_URL, SITE_NAME, SITE_TAGLINE, SITE_DESCRIPTION } from "@/lib/site";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -14,10 +15,42 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
+// The site shipped for months under the project's original name, CodeEarn,
+// which no longer exists as a product: every search result, link preview and
+// social unfurl advertised a credit-earning scheme this is not. Metadata now
+// comes from one place so the name cannot drift again.
 export const metadata: Metadata = {
-  title: "CodeEarn - Earn while you code",
-  description:
-    "Earn credits while waiting for AI agent responses. Powered by Claude Code.",
+  metadataBase: new URL(SITE_URL),
+  title: {
+    default: `${SITE_NAME} — ${SITE_TAGLINE}`,
+    template: `%s — ${SITE_NAME}`,
+  },
+  description: SITE_DESCRIPTION,
+  applicationName: SITE_NAME,
+  keywords: [
+    "claude code",
+    "claude code plugin",
+    "status line",
+    "statusline",
+    "hacker news",
+    "github trending",
+    "developer news",
+  ],
+  authors: [{ name: "bhpark1013", url: "https://github.com/bhpark1013" }],
+  creator: "bhpark1013",
+  alternates: { canonical: "/" },
+  openGraph: {
+    type: "website",
+    siteName: SITE_NAME,
+    title: `${SITE_NAME} — ${SITE_TAGLINE}`,
+    description: SITE_DESCRIPTION,
+    url: "/",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: `${SITE_NAME} — ${SITE_TAGLINE}`,
+    description: SITE_DESCRIPTION,
+  },
 };
 
 export default function RootLayout({

--- a/web/src/app/opengraph-image.tsx
+++ b/web/src/app/opengraph-image.tsx
@@ -1,0 +1,86 @@
+import { ImageResponse } from "next/og";
+import { SITE_NAME, SITE_TAGLINE } from "@/lib/site";
+
+// Generated rather than committed as a PNG: the card is a picture of the
+// status line, which is the whole product, and keeping it as code means it
+// cannot fall out of sync with the copy the way a screenshot does.
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+export const alt = `${SITE_NAME} — ${SITE_TAGLINE}`;
+
+export default function OpengraphImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          background: "#0b0d10",
+          color: "#e6e9ef",
+          padding: "0 84px",
+          fontFamily: "monospace",
+        }}
+      >
+        <div style={{ display: "flex", fontSize: 30, color: "#7c8595" }}>
+          {SITE_NAME}
+        </div>
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            fontSize: 78,
+            fontWeight: 700,
+            lineHeight: 1.15,
+            marginTop: 18,
+          }}
+        >
+          <div style={{ display: "flex" }}>Dev news,</div>
+          <div style={{ display: "flex" }}>while AI thinks.</div>
+        </div>
+
+        {/* The status line itself, rendered the way the plugin draws it. */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            marginTop: 56,
+            padding: "26px 32px",
+            borderRadius: 14,
+            background: "#15181e",
+            border: "1px solid #262b34",
+            fontSize: 28,
+          }}
+        >
+          <div style={{ display: "flex", color: "#56b6c2" }}>HackerNews</div>
+          {/* A drawn rule, not the "│" the terminal uses: the OG renderer's
+              font has no glyph for it and emits a tofu box. */}
+          <div
+            style={{
+              display: "flex",
+              width: 1,
+              height: 30,
+              background: "#4b5263",
+              margin: "0 18px",
+            }}
+          />
+          <div style={{ display: "flex", color: "#e6e9ef" }}>
+            Nine coding harnesses vs. your laptop
+          </div>
+          <div style={{ display: "flex", color: "#e5c07b", paddingLeft: 20 }}>
+            ▲46
+          </div>
+        </div>
+
+        <div
+          style={{ display: "flex", marginTop: 34, fontSize: 26, color: "#7c8595" }}
+        >
+          Hacker News · GitHub Trending · your own feeds — in Claude Code
+        </div>
+      </div>
+    ),
+    size
+  );
+}

--- a/web/src/app/robots.ts
+++ b/web/src/app/robots.ts
@@ -1,0 +1,13 @@
+import type { MetadataRoute } from "next";
+import { SITE_URL } from "@/lib/site";
+
+// There was no robots.txt at all, so crawlers had no sitemap to follow and the
+// API routes were as crawlable as the landing page. Those return JSON for the
+// plugin, not pages worth indexing.
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [{ userAgent: "*", allow: "/", disallow: "/api/" }],
+    sitemap: `${SITE_URL}/sitemap.xml`,
+    host: SITE_URL,
+  };
+}

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -1,0 +1,15 @@
+import type { MetadataRoute } from "next";
+import { SITE_URL } from "@/lib/site";
+
+// One entry today because the landing page is the only indexable route. When
+// the public reader lands, its item pages are appended here.
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: SITE_URL,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 1,
+    },
+  ];
+}

--- a/web/src/lib/site.ts
+++ b/web/src/lib/site.ts
@@ -1,0 +1,25 @@
+/**
+ * Canonical origin for the public site.
+ *
+ * Kept in one place and driven by env so moving off the generated Vercel
+ * hostname onto a real domain is a single environment-variable change rather
+ * than a search-and-replace across metadata, robots and the sitemap.
+ *
+ * Order: an explicit override, then the production deployment Vercel tells us
+ * about, then the current deployment. The final literal only applies to a
+ * local build with no Vercel env at all.
+ */
+const fromVercel = (host?: string) => (host ? `https://${host}` : undefined);
+
+export const SITE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL ??
+  fromVercel(process.env.VERCEL_PROJECT_PRODUCTION_URL) ??
+  fromVercel(process.env.VERCEL_URL) ??
+  "https://web-olive-three-47.vercel.app";
+
+export const SITE_NAME = "claudenews";
+
+export const SITE_TAGLINE = "Dev news, while AI thinks.";
+
+export const SITE_DESCRIPTION =
+  "A Claude Code plugin that puts Hacker News, GitHub Trending and per-language dev feeds in your status line while the agent works — auto-translated, with short summaries. Free and MIT licensed.";


### PR DESCRIPTION
## The bug

The public site's `<title>` and description were still the project's original name:

```html
<title>CodeEarn - Earn while you code</title>
<meta name="description" content="Earn credits while waiting for AI agent responses.">
```

The page body has said claudenews for months. Only the metadata — the part Google, Slack and X actually show — kept advertising a credit-earning product that does not exist. Every link we place in a directory, a community post or a README landed on that.

Also missing entirely: `robots.txt` (so crawlers had no sitemap to follow, and `/api/*` was as crawlable as the landing page), `sitemap.xml`, and any OpenGraph card.

## Changes

- **`lib/site.ts`** — one source for name, tagline, description and canonical origin. The origin is env-driven (`NEXT_PUBLIC_SITE_URL` → `VERCEL_PROJECT_PRODUCTION_URL` → `VERCEL_URL`), so moving onto a real domain is one environment variable, not a search-and-replace.
- **`layout.tsx`** — real title/description, `metadataBase`, canonical, keywords, author, full `openGraph` and `twitter` blocks.
- **`robots.ts`** — allow `/`, disallow `/api/`, point at the sitemap.
- **`sitemap.ts`** — the landing page today; item pages append here when the public reader lands.
- **`opengraph-image.tsx`** — a generated 1200×630 card drawing the status line itself. Generated rather than committed as a PNG so it cannot drift from the copy.

## Verified against a production build

| | |
|---|---|
| `<title>` | `claudenews — Dev news, while AI thinks.` |
| description | claudenews copy, not CodeEarn |
| canonical / `og:url` | resolves from `SITE_URL` |
| `og:image` | 200, `image/png`, 1200×630 |
| `robots.txt` | serves, references sitemap |
| `sitemap.xml` | valid urlset |

The first render of the card showed a tofu box where the terminal's `│` goes — the OG renderer's font has no glyph for it. Replaced with a drawn rule and re-verified.

https://claude.ai/code/session_013ZS4io8TJKUivqTbBpTPdy